### PR TITLE
 Fix should regard double quote string as an ident

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -902,10 +902,10 @@ func (a *TableIndex) Accept(visitor ASTVisitor) error {
 }
 
 type Ident struct {
-	Name     string
-	Unquoted bool
-	NamePos  Pos
-	NameEnd  Pos
+	Name      string
+	QuoteType int
+	NamePos   Pos
+	NameEnd   Pos
 }
 
 func (i *Ident) Pos() Pos {
@@ -917,8 +917,10 @@ func (i *Ident) End() Pos {
 }
 
 func (i *Ident) String(int) string {
-	if i.Unquoted {
+	if i.QuoteType == BackTicks {
 		return "`" + i.Name + "`"
+	} else if i.QuoteType == DoubleQuote {
+		return `"` + i.Name + `"`
 	}
 	return i.Name
 }
@@ -1749,8 +1751,8 @@ func (n *NotNullLiteral) Accept(visitor ASTVisitor) error {
 }
 
 type NestedIdentifier struct {
-	Ident    Expr
-	DotIdent Expr
+	Ident    *Ident
+	DotIdent *Ident
 }
 
 func (n *NestedIdentifier) Pos() Pos {
@@ -1835,8 +1837,8 @@ func (c *ColumnIdentifier) Accept(visitor ASTVisitor) error {
 }
 
 type TableIdentifier struct {
-	Database Expr
-	Table    Expr
+	Database *Ident
+	Table    *Ident
 }
 
 func (t *TableIdentifier) Pos() Pos {

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -21,7 +21,7 @@ func (p *Parser) parseExpr(pos Pos) (Expr, error) {
 	case p.matchKeyword(KeywordAs): // syntax: columnExpr (alias | AS identifier)
 		aliasPos := p.Pos()
 		_ = p.lexer.consumeToken()
-		alias, err := p.parseIdentOrString(p.Pos())
+		alias, err := p.parseIdent()
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -84,23 +84,12 @@ func (p *Parser) parseIdent() (*Ident, error) {
 		return nil, err
 	}
 	ident := &Ident{
-		NamePos:  lastToken.Pos,
-		NameEnd:  lastToken.End,
-		Name:     lastToken.String,
-		Unquoted: lastToken.Unquoted,
+		NamePos:   lastToken.Pos,
+		NameEnd:   lastToken.End,
+		Name:      lastToken.String,
+		QuoteType: lastToken.QuoteType,
 	}
 	return ident, nil
-}
-
-func (p *Parser) parseIdentOrString(_ Pos) (Expr, error) {
-	switch {
-	case p.matchTokenKind(TokenIdent):
-		return p.parseIdent()
-	case p.matchTokenKind(TokenString):
-		return p.parseString(p.Pos())
-	default:
-		return nil, fmt.Errorf("expected <ident> or <string>, but got %q", p.lastTokenKind())
-	}
 }
 
 func (p *Parser) parseIdentOrStar() (*Ident, error) {
@@ -120,11 +109,11 @@ func (p *Parser) parseIdentOrStar() (*Ident, error) {
 	}
 }
 
-func (p *Parser) tryParseDotIdent(pos Pos) (Expr, error) {
+func (p *Parser) tryParseDotIdent(_ Pos) (*Ident, error) {
 	if p.tryConsumeTokenKind(".") == nil {
 		return nil, nil // nolint
 	}
-	return p.parseIdentOrString(pos)
+	return p.parseIdent()
 }
 
 func (p *Parser) parseUUID() (*UUID, error) {
@@ -258,7 +247,7 @@ func (p *Parser) parseLiteral(pos Pos) (Literal, error) {
 }
 
 func (p *Parser) ParseNestedIdentifier(pos Pos) (*NestedIdentifier, error) {
-	ident, err := p.parseIdentOrString(pos)
+	ident, err := p.parseIdent()
 	if err != nil {
 		return nil, err
 	}

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -79,7 +79,7 @@ func (p *Parser) parseCreateDatabase(pos Pos) (*CreateDatabase, error) {
 		return nil, err
 	}
 	// parse database name
-	name, err := p.parseIdentOrString(p.Pos())
+	name, err := p.parseIdent()
 	if err != nil {
 		return nil, err
 	}
@@ -254,8 +254,8 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 	return ident, nil
 }
 
-func (p *Parser) parseTableIdentifier(pos Pos) (*TableIdentifier, error) {
-	ident, err := p.parseIdentOrString(pos)
+func (p *Parser) parseTableIdentifier(_ Pos) (*TableIdentifier, error) {
+	ident, err := p.parseIdent()
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,16 @@ func (p *Parser) tryParseOnCluster(pos Pos) (*OnClusterExpr, error) {
 		return nil, err
 	}
 
-	expr, err := p.parseIdentOrString(p.Pos())
+	var expr Expr
+	var err error
+	switch {
+	case p.matchTokenKind(TokenIdent):
+		expr, err = p.parseIdent()
+	case p.matchTokenKind(TokenString):
+		expr, err = p.parseString(p.Pos())
+	default:
+		return nil, fmt.Errorf("unexpected token: %q, expected <IDENT> or <STRING>", p.last().String)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/parser/testdata/basic/output/use_database.sql.golden.json
+++ b/parser/testdata/basic/output/use_database.sql.golden.json
@@ -4,7 +4,7 @@
     "StatementEnd": 8,
     "Database": {
       "Name": "test",
-      "Unquoted": false,
+      "QuoteType": 1,
       "NamePos": 4,
       "NameEnd": 8
     }

--- a/parser/testdata/ddl/output/alter_role.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_role.sql.golden.json
@@ -8,7 +8,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 33,
             "NameEnd": 41
           },
@@ -30,7 +30,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 54,
             "NameEnd": 62
           },
@@ -39,7 +39,7 @@
             "OnPos": 63,
             "Expr": {
               "Name": "cluster_1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 74,
               "NameEnd": 83
             }
@@ -47,7 +47,7 @@
         },
         "NewName": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 94,
           "NameEnd": 102
         },
@@ -65,7 +65,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 115,
             "NameEnd": 123
           },
@@ -74,7 +74,7 @@
         },
         "NewName": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 134,
           "NameEnd": 142
         },
@@ -84,7 +84,7 @@
         "RoleName": {
           "Name": {
             "Name": "r3_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 144,
             "NameEnd": 152
           },
@@ -93,7 +93,7 @@
         },
         "NewName": {
           "Name": "r4_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 163,
           "NameEnd": 171
         },
@@ -111,7 +111,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 184,
             "NameEnd": 192
           },
@@ -127,7 +127,7 @@
         "SettingPairs": [],
         "Modifier": {
           "Name": "NONE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 202,
           "NameEnd": 206
         }
@@ -143,7 +143,7 @@
         "RoleName": {
           "Name": {
             "Name": "r2_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 219,
             "NameEnd": 227
           },
@@ -160,7 +160,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 237,
               "NameEnd": 244
             },
@@ -184,7 +184,7 @@
         "RoleName": {
           "Name": {
             "Name": "r3_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 267,
             "NameEnd": 275
           },
@@ -201,7 +201,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 285,
               "NameEnd": 301
             },
@@ -226,7 +226,7 @@
         "RoleName": {
           "Name": {
             "Name": "r4_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 322,
             "NameEnd": 330
           },
@@ -243,7 +243,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 340,
               "NameEnd": 356
             },
@@ -252,7 +252,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 357,
               "NameEnd": 360
             },
@@ -277,7 +277,7 @@
         "RoleName": {
           "Name": {
             "Name": "r5_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 381,
             "NameEnd": 389
           },
@@ -294,7 +294,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 399,
               "NameEnd": 415
             },
@@ -303,7 +303,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 416,
               "NameEnd": 419
             },
@@ -328,7 +328,7 @@
         "RoleName": {
           "Name": {
             "Name": "r6_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 440,
             "NameEnd": 448
           },
@@ -345,7 +345,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 458,
               "NameEnd": 474
             },
@@ -354,7 +354,7 @@
         ],
         "Modifier": {
           "Name": "CONST",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 475,
           "NameEnd": 480
         }
@@ -370,7 +370,7 @@
         "RoleName": {
           "Name": {
             "Name": "r7_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 493,
             "NameEnd": 501
           },
@@ -387,7 +387,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 511,
               "NameEnd": 527
             },
@@ -396,7 +396,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 528,
           "NameEnd": 536
         }
@@ -412,7 +412,7 @@
         "RoleName": {
           "Name": {
             "Name": "r8_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 549,
             "NameEnd": 557
           },
@@ -429,7 +429,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 567,
               "NameEnd": 583
             },
@@ -443,7 +443,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 592,
               "NameEnd": 595
             },
@@ -457,7 +457,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 604,
               "NameEnd": 607
             },
@@ -471,7 +471,7 @@
         ],
         "Modifier": {
           "Name": "CONST",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 616,
           "NameEnd": 621
         }
@@ -487,7 +487,7 @@
         "RoleName": {
           "Name": {
             "Name": "r9_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 634,
             "NameEnd": 642
           },
@@ -504,7 +504,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 652,
               "NameEnd": 659
             },
@@ -522,7 +522,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 671,
               "NameEnd": 687
             },
@@ -536,7 +536,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 696,
           "NameEnd": 704
         }
@@ -552,7 +552,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 717,
             "NameEnd": 725
           },
@@ -566,7 +566,7 @@
         "RoleName": {
           "Name": {
             "Name": "r2_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 727,
             "NameEnd": 735
           },
@@ -588,7 +588,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 748,
             "NameEnd": 756
           },
@@ -605,7 +605,7 @@
           {
             "Name": {
               "Name": "readonly",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 766,
               "NameEnd": 774
             },
@@ -630,7 +630,7 @@
         "RoleName": {
           "Name": {
             "Name": "r2_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 789,
             "NameEnd": 797
           },
@@ -647,7 +647,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 807,
               "NameEnd": 814
             },
@@ -671,7 +671,7 @@
         "RoleName": {
           "Name": {
             "Name": "r3_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 837,
             "NameEnd": 845
           },
@@ -688,7 +688,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 855,
               "NameEnd": 871
             },
@@ -702,7 +702,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 880,
               "NameEnd": 883
             },
@@ -716,7 +716,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 892,
               "NameEnd": 895
             },
@@ -730,7 +730,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 904,
           "NameEnd": 912
         }
@@ -746,7 +746,7 @@
         "RoleName": {
           "Name": {
             "Name": "r4_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 925,
             "NameEnd": 933
           },
@@ -763,7 +763,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 943,
               "NameEnd": 950
             },
@@ -781,7 +781,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 962,
               "NameEnd": 978
             },
@@ -800,7 +800,7 @@
           {
             "Name": {
               "Name": "readonly",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 988,
               "NameEnd": 996
             },
@@ -825,7 +825,7 @@
         "RoleName": {
           "Name": {
             "Name": "r5_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 1011,
             "NameEnd": 1019
           },
@@ -841,7 +841,7 @@
         "SettingPairs": [],
         "Modifier": {
           "Name": "NONE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1029,
           "NameEnd": 1033
         }
@@ -857,7 +857,7 @@
         "RoleName": {
           "Name": {
             "Name": "r1_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 1046,
             "NameEnd": 1054
           },
@@ -883,7 +883,7 @@
         "RoleName": {
           "Name": {
             "Name": "r2_01293",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 1071,
             "NameEnd": 1079
           },

--- a/parser/testdata/ddl/output/alter_table_add_column.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_add_column.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 29
       }
@@ -33,14 +33,14 @@
           "ColumnEnd": 79,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 70,
             "NameEnd": 72
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 73,
               "NameEnd": 79
             }
@@ -57,7 +57,7 @@
         "After": {
           "Ident": {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 86,
             "NameEnd": 88
           },

--- a/parser/testdata/ddl/output/alter_table_add_index.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_add_index.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 29
       }
@@ -33,7 +33,7 @@
           "Name": {
             "Ident": {
               "Name": "my_index",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 69,
               "NameEnd": 77
             },
@@ -49,7 +49,7 @@
               "Items": [
                 {
                   "Name": "f0",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 78,
                   "NameEnd": 80
                 }
@@ -60,7 +60,7 @@
           "ColumnType": {
             "Name": {
               "Name": "minmax",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 87,
               "NameEnd": 93
             }

--- a/parser/testdata/ddl/output/alter_table_attach_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_attach_partition.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       }
@@ -36,7 +36,7 @@
       "Database": null,
       "Table": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 58,
         "NameEnd": 62
       }
@@ -59,7 +59,7 @@
           "Database": null,
           "Table": {
             "Name": "test1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 96,
             "NameEnd": 101
           }
@@ -74,7 +74,7 @@
       "Database": null,
       "Table": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 115,
         "NameEnd": 119
       }

--- a/parser/testdata/ddl/output/alter_table_clear_column.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_clear_column.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "my_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 20
       }
@@ -20,7 +20,7 @@
         "ColumnName": {
           "Ident": {
             "Name": "my_column_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 34,
             "NameEnd": 48
           },
@@ -30,7 +30,7 @@
           "PartitionPos": 52,
           "Expr": {
             "Name": "partition_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 62,
             "NameEnd": 76
           },

--- a/parser/testdata/ddl/output/alter_table_clear_index.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_clear_index.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "my_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 20
       }
@@ -20,7 +20,7 @@
         "IndexName": {
           "Ident": {
             "Name": "my_index_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 33,
             "NameEnd": 46
           },
@@ -30,7 +30,7 @@
           "PartitionPos": 50,
           "Expr": {
             "Name": "partition_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 60,
             "NameEnd": 74
           },

--- a/parser/testdata/ddl/output/alter_table_detach_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_detach_partition.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "db",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 14
       },
       "Table": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 15,
         "NameEnd": 19
       }

--- a/parser/testdata/ddl/output/alter_table_drop_column.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_drop_column.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 29
       }
@@ -30,7 +30,7 @@
         "ColumnName": {
           "Ident": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 81,
             "NameEnd": 83
           },

--- a/parser/testdata/ddl/output/alter_table_drop_detach_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_drop_detach_partition.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "app_utc_00",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 22
       },
       "Table": {
         "Name": "app_message_as_notification_organization_sent_stats_i_d_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 23,
         "NameEnd": 84
       }
@@ -38,7 +38,7 @@
               "SettingsPos": 131,
               "Name": {
                 "Name": "allow_drop_detached",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 131,
                 "NameEnd": 150
               },

--- a/parser/testdata/ddl/output/alter_table_drop_index.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_drop_index.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "event_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 28
       }
@@ -30,7 +30,7 @@
         "IndexName": {
           "Ident": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 69,
             "NameEnd": 71
           },

--- a/parser/testdata/ddl/output/alter_table_drop_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_drop_partition.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 23
       }

--- a/parser/testdata/ddl/output/alter_table_freeze_no_specify_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_freeze_no_specify_partition.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 23
       }

--- a/parser/testdata/ddl/output/alter_table_freeze_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_freeze_partition.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 23
       }

--- a/parser/testdata/ddl/output/alter_table_modify_column.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_modify_column.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "t1",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 14
       }
@@ -22,14 +22,14 @@
           "ColumnEnd": 52,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 29,
             "NameEnd": 31
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 32,
               "NameEnd": 38
             }

--- a/parser/testdata/ddl/output/alter_table_modify_column_remove.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_modify_column_remove.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "t1",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 14
       }
@@ -22,7 +22,7 @@
           "ColumnEnd": 31,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 29,
             "NameEnd": 31
           },
@@ -40,7 +40,7 @@
           "PropertyType": {
             "Name": {
               "Name": "COMMENT",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 39,
               "NameEnd": 46
             }

--- a/parser/testdata/ddl/output/alter_table_remove_ttl.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_remove_ttl.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "events",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 23
       }

--- a/parser/testdata/ddl/output/alter_table_rename_column.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_rename_column.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "my_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 20
       }
@@ -19,7 +19,7 @@
         "OldColumnName": {
           "Ident": {
             "Name": "old_column_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 35,
             "NameEnd": 50
           },
@@ -28,7 +28,7 @@
         "NewColumnName": {
           "Ident": {
             "Name": "new_column_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 54,
             "NameEnd": 69
           },

--- a/parser/testdata/ddl/output/alter_table_replace_partition.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_replace_partition.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "t2",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 14
       }
@@ -29,7 +29,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 50,
             "NameEnd": 52
           }

--- a/parser/testdata/ddl/output/attach_table_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/attach_table_basic.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 27,
         "NameEnd": 31
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 32,
         "NameEnd": 44
       }
@@ -35,14 +35,14 @@
           "ColumnEnd": 89,
           "Name": {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 80,
             "NameEnd": 82
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 83,
               "NameEnd": 89
             }
@@ -60,14 +60,14 @@
           "ColumnEnd": 104,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 95,
             "NameEnd": 97
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 98,
               "NameEnd": 104
             }
@@ -85,14 +85,14 @@
           "ColumnEnd": 119,
           "Name": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 110,
             "NameEnd": 112
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 113,
               "NameEnd": 119
             }
@@ -110,14 +110,14 @@
           "ColumnEnd": 136,
           "Name": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 125,
             "NameEnd": 127
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 128,
               "NameEnd": 136
             }
@@ -135,14 +135,14 @@
           "ColumnEnd": 153,
           "Name": {
             "Name": "f4",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 142,
             "NameEnd": 144
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 145,
               "NameEnd": 153
             }
@@ -160,7 +160,7 @@
           "ColumnEnd": 179,
           "Name": {
             "Name": "f5",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 159,
             "NameEnd": 161
           },
@@ -169,7 +169,7 @@
             "RightParenPos": 179,
             "Name": {
               "Name": "Map",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 162,
               "NameEnd": 165
             },
@@ -177,7 +177,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 166,
                   "NameEnd": 172
                 }
@@ -185,7 +185,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 173,
                   "NameEnd": 179
                 }
@@ -205,14 +205,14 @@
           "ColumnEnd": 195,
           "Name": {
             "Name": "f6",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 186,
             "NameEnd": 188
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 189,
               "NameEnd": 195
             }
@@ -230,14 +230,14 @@
           "ColumnEnd": 225,
           "Name": {
             "Name": "f7",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 201,
             "NameEnd": 203
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 204,
               "NameEnd": 212
             }
@@ -249,7 +249,7 @@
             "Expr": {
               "Name": {
                 "Name": "now",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 221,
                 "NameEnd": 224
               },
@@ -312,7 +312,7 @@
             {
               "Name": {
                 "Name": "toYYYYMMDD",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 366,
                 "NameEnd": 376
               },
@@ -326,7 +326,7 @@
                   "Items": [
                     {
                       "Name": "f3",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 377,
                       "NameEnd": 379
                     }
@@ -348,7 +348,7 @@
             "Expr": {
               "LeftExpr": {
                 "Name": "f3",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 331,
                 "NameEnd": 333
               },
@@ -363,7 +363,7 @@
                 },
                 "Unit": {
                   "Name": "MONTH",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 347,
                   "NameEnd": 352
                 }
@@ -391,19 +391,19 @@
                 "Items": [
                   {
                     "Name": "f0",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 391,
                     "NameEnd": 393
                   },
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 394,
                     "NameEnd": 396
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 397,
                     "NameEnd": 399
                   }

--- a/parser/testdata/ddl/output/bug_001.sql.golden.json
+++ b/parser/testdata/ddl/output/bug_001.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "db",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 39,
         "NameEnd": 41
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 42,
         "NameEnd": 47
       }
@@ -31,13 +31,13 @@
       "TableIdentifier": {
         "Database": {
           "Name": "db",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 92,
           "NameEnd": 94
         },
         "Table": {
           "Name": "table_mv",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 95,
           "NameEnd": 103
         }
@@ -58,13 +58,13 @@
           "Items": [
             {
               "Name": "event_ts",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 118,
               "NameEnd": 126
             },
             {
               "Name": "org_id",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 132,
               "NameEnd": 138
             },
@@ -72,7 +72,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 144,
                   "NameEnd": 167
                 },
@@ -86,7 +86,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 168,
                         "NameEnd": 178
                       },
@@ -103,7 +103,7 @@
               "AliasPos": 185,
               "Alias": {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 188,
                 "NameEnd": 189
               }
@@ -112,7 +112,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 195,
                   "NameEnd": 218
                 },
@@ -126,7 +126,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 219,
                         "NameEnd": 229
                       },
@@ -143,7 +143,7 @@
               "AliasPos": 236,
               "Alias": {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 239,
                 "NameEnd": 240
               }
@@ -152,7 +152,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 246,
                   "NameEnd": 269
                 },
@@ -166,7 +166,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 270,
                         "NameEnd": 280
                       },
@@ -183,7 +183,7 @@
               "AliasPos": 287,
               "Alias": {
                 "Name": "z",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 290,
                 "NameEnd": 291
               }
@@ -192,7 +192,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 297,
                   "NameEnd": 320
                 },
@@ -206,7 +206,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 321,
                         "NameEnd": 331
                       },
@@ -223,7 +223,7 @@
               "AliasPos": 338,
               "Alias": {
                 "Name": "a",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 341,
                 "NameEnd": 342
               }
@@ -232,7 +232,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 348,
                   "NameEnd": 371
                 },
@@ -246,7 +246,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 372,
                         "NameEnd": 382
                       },
@@ -263,7 +263,7 @@
               "AliasPos": 389,
               "Alias": {
                 "Name": "b",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 392,
                 "NameEnd": 393
               }
@@ -272,7 +272,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 399,
                   "NameEnd": 422
                 },
@@ -286,7 +286,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 423,
                         "NameEnd": 433
                       },
@@ -303,7 +303,7 @@
               "AliasPos": 440,
               "Alias": {
                 "Name": "c",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 443,
                 "NameEnd": 444
               }
@@ -312,7 +312,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 450,
                   "NameEnd": 473
                 },
@@ -326,7 +326,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 474,
                         "NameEnd": 484
                       },
@@ -343,7 +343,7 @@
               "AliasPos": 491,
               "Alias": {
                 "Name": "d",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 494,
                 "NameEnd": 495
               }
@@ -352,7 +352,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractInt",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 501,
                   "NameEnd": 521
                 },
@@ -366,7 +366,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 522,
                         "NameEnd": 532
                       },
@@ -383,7 +383,7 @@
               "AliasPos": 539,
               "Alias": {
                 "Name": "e",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 542,
                 "NameEnd": 543
               }
@@ -392,7 +392,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractInt",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 549,
                   "NameEnd": 569
                 },
@@ -406,7 +406,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 570,
                         "NameEnd": 580
                       },
@@ -423,7 +423,7 @@
               "AliasPos": 587,
               "Alias": {
                 "Name": "f",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 590,
                 "NameEnd": 591
               }
@@ -439,13 +439,13 @@
             "Expr": {
               "Database": {
                 "Name": "db",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 597,
                 "NameEnd": 599
               },
               "Table": {
                 "Name": "table",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 600,
                 "NameEnd": 605
               }
@@ -462,19 +462,19 @@
             "LeftExpr": {
               "Database": {
                 "Name": "db",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 612,
                 "NameEnd": 614
               },
               "Table": {
                 "Name": "table",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 615,
                 "NameEnd": 620
               },
               "Column": {
                 "Name": "event",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 621,
                 "NameEnd": 626
               }

--- a/parser/testdata/ddl/output/check.sql.golden.json
+++ b/parser/testdata/ddl/output/check.sql.golden.json
@@ -5,7 +5,7 @@
       "Database": null,
       "Table": {
         "Name": "test_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 22
       }
@@ -18,7 +18,7 @@
       "Database": null,
       "Table": {
         "Name": "test_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 36,
         "NameEnd": 46
       }

--- a/parser/testdata/ddl/output/create_database.sql.golden.json
+++ b/parser/testdata/ddl/output/create_database.sql.golden.json
@@ -4,7 +4,7 @@
     "StatementEnd": 35,
     "Name": {
       "Name": "test",
-      "Unquoted": true,
+      "QuoteType": 3,
       "NamePos": 31,
       "NameEnd": 35
     },

--- a/parser/testdata/ddl/output/create_distributed_table.sql.golden.json
+++ b/parser/testdata/ddl/output/create_distributed_table.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 13,
         "NameEnd": 17
       },
       "Table": {
         "Name": "event_all",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 18,
         "NameEnd": 27
       }
@@ -33,13 +33,13 @@
       "AliasTable": {
         "Database": {
           "Name": "test",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 60,
           "NameEnd": 64
         },
         "Table": {
           "Name": "evnets_local",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 65,
           "NameEnd": 77
         }
@@ -60,26 +60,26 @@
           "Items": [
             {
               "Name": "default_cluster",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 104,
               "NameEnd": 119
             },
             {
               "Name": "test",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 125,
               "NameEnd": 129
             },
             {
               "Name": "events_local",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 135,
               "NameEnd": 147
             },
             {
               "Name": {
                 "Name": "rand",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 153,
                 "NameEnd": 157
               },
@@ -111,7 +111,7 @@
             "SettingsPos": 171,
             "Name": {
               "Name": "fsync_after_insert",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 171,
               "NameEnd": 189
             },

--- a/parser/testdata/ddl/output/create_function_simple.sql.golden.json
+++ b/parser/testdata/ddl/output/create_function_simple.sql.golden.json
@@ -4,7 +4,7 @@
     "IfNotExists": false,
     "FunctionName": {
       "Name": "linear_equation",
-      "Unquoted": false,
+      "QuoteType": 1,
       "NamePos": 16,
       "NameEnd": 31
     },
@@ -19,19 +19,19 @@
         "Items": [
           {
             "Name": "x",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 36,
             "NameEnd": 37
           },
           {
             "Name": "k",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 39,
             "NameEnd": 40
           },
           {
             "Name": "b",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 42,
             "NameEnd": 43
           }
@@ -43,14 +43,14 @@
       "LeftExpr": {
         "LeftExpr": {
           "Name": "k",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 48,
           "NameEnd": 49
         },
         "Operation": "*",
         "RightExpr": {
           "Name": "x",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 50,
           "NameEnd": 51
         },
@@ -60,7 +60,7 @@
       "Operation": "+",
       "RightExpr": {
         "Name": "b",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 54,
         "NameEnd": 55
       },

--- a/parser/testdata/ddl/output/create_live_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_live_view_basic.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "my_live_view",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 29
       }
@@ -20,7 +20,7 @@
         "Database": null,
         "Table": {
           "Name": "my_destination",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 49,
           "NameEnd": 63
         }
@@ -36,14 +36,14 @@
           "ColumnEnd": 73,
           "Name": {
             "Name": "id",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 64,
             "NameEnd": 66
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 67,
               "NameEnd": 73
             }
@@ -84,7 +84,7 @@
           "Items": [
             {
               "Name": "id",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 85,
               "NameEnd": 87
             }
@@ -100,7 +100,7 @@
               "Database": null,
               "Table": {
                 "Name": "my_table",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 93,
                 "NameEnd": 101
               }

--- a/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "infra_bm",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 25,
         "NameEnd": 33
       },
       "Table": {
         "Name": "view_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 34,
         "NameEnd": 43
       }
@@ -31,13 +31,13 @@
       "TableIdentifier": {
         "Database": {
           "Name": "infra_bm",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 81,
           "NameEnd": 89
         },
         "Table": {
           "Name": "table_name",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 90,
           "NameEnd": 100
         }
@@ -51,7 +51,7 @@
             "ColumnEnd": 122,
             "Name": {
               "Name": "f1",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 106,
               "NameEnd": 108
             },
@@ -60,7 +60,7 @@
               "RightParenPos": 122,
               "Name": {
                 "Name": "DateTime64",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 110,
                 "NameEnd": 120
               },
@@ -86,14 +86,14 @@
             "ColumnEnd": 139,
             "Name": {
               "Name": "f2",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 129,
               "NameEnd": 131
             },
             "Type": {
               "Name": {
                 "Name": "String",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 133,
                 "NameEnd": 139
               }
@@ -111,14 +111,14 @@
             "ColumnEnd": 155,
             "Name": {
               "Name": "f3",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 145,
               "NameEnd": 147
             },
             "Type": {
               "Name": {
                 "Name": "String",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 149,
                 "NameEnd": 155
               }
@@ -136,14 +136,14 @@
             "ColumnEnd": 171,
             "Name": {
               "Name": "f4",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 161,
               "NameEnd": 163
             },
             "Type": {
               "Name": {
                 "Name": "String",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 165,
                 "NameEnd": 171
               }
@@ -161,14 +161,14 @@
             "ColumnEnd": 187,
             "Name": {
               "Name": "f5",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 177,
               "NameEnd": 179
             },
             "Type": {
               "Name": {
                 "Name": "String",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 181,
                 "NameEnd": 187
               }
@@ -186,14 +186,14 @@
             "ColumnEnd": 202,
             "Name": {
               "Name": "f6",
-              "Unquoted": true,
+              "QuoteType": 3,
               "NamePos": 193,
               "NameEnd": 195
             },
             "Type": {
               "Name": {
                 "Name": "Int64",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 197,
                 "NameEnd": 202
               }
@@ -225,13 +225,13 @@
           "Items": [
             {
               "Name": "f1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 215,
               "NameEnd": 217
             },
             {
               "Name": "f2",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 226,
               "NameEnd": 228
             },
@@ -239,7 +239,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 237,
                   "NameEnd": 260
                 },
@@ -253,7 +253,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 261,
                         "NameEnd": 271
                       },
@@ -270,7 +270,7 @@
               "AliasPos": 281,
               "Alias": {
                 "Name": "f3",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 284,
                 "NameEnd": 286
               }
@@ -279,7 +279,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 295,
                   "NameEnd": 318
                 },
@@ -293,7 +293,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 319,
                         "NameEnd": 329
                       },
@@ -310,7 +310,7 @@
               "AliasPos": 342,
               "Alias": {
                 "Name": "f4",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 345,
                 "NameEnd": 347
               }
@@ -319,7 +319,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractString",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 356,
                   "NameEnd": 379
                 },
@@ -333,7 +333,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 380,
                         "NameEnd": 390
                       },
@@ -350,7 +350,7 @@
               "AliasPos": 401,
               "Alias": {
                 "Name": "f5",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 404,
                 "NameEnd": 406
               }
@@ -359,7 +359,7 @@
               "Expr": {
                 "Name": {
                   "Name": "visitParamExtractInt",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 412,
                   "NameEnd": 432
                 },
@@ -373,7 +373,7 @@
                     "Items": [
                       {
                         "Name": "properties",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 433,
                         "NameEnd": 443
                       },
@@ -390,7 +390,7 @@
               "AliasPos": 451,
               "Alias": {
                 "Name": "f6",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 454,
                 "NameEnd": 456
               }
@@ -406,13 +406,13 @@
             "Expr": {
               "Database": {
                 "Name": "infra_bm",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 466,
                 "NameEnd": 474
               },
               "Table": {
                 "Name": "table_name1",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 475,
                 "NameEnd": 486
               }
@@ -429,19 +429,19 @@
             "LeftExpr": {
               "Database": {
                 "Name": "infra_bm",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 497,
                 "NameEnd": 505
               },
               "Table": {
                 "Name": "table_name1",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 506,
                 "NameEnd": 517
               },
               "Column": {
                 "Name": "event",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 518,
                 "NameEnd": 523
               }

--- a/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 25,
         "NameEnd": 29
       },
       "Table": {
         "Name": "t0",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 30,
         "NameEnd": 32
       }
@@ -21,7 +21,7 @@
       "OnPos": 33,
       "Expr": {
         "Name": "default_cluster",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 44,
         "NameEnd": 59
       }
@@ -63,7 +63,7 @@
             {
               "Name": {
                 "Name": "toYYYYMM",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 165,
                 "NameEnd": 173
               },
@@ -77,7 +77,7 @@
                   "Items": [
                     {
                       "Name": "f0",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 174,
                       "NameEnd": 176
                     }
@@ -108,7 +108,7 @@
                 "Items": [
                   {
                     "Name": "f0",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 188,
                     "NameEnd": 190
                   }
@@ -136,19 +136,19 @@
           "Items": [
             {
               "Name": "f0",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 211,
               "NameEnd": 213
             },
             {
               "Name": "f1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 214,
               "NameEnd": 216
             },
             {
               "Name": "f2",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 217,
               "NameEnd": 219
             },
@@ -156,7 +156,7 @@
               "Expr": {
                 "Name": {
                   "Name": "coalesce",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 220,
                   "NameEnd": 228
                 },
@@ -170,13 +170,13 @@
                     "Items": [
                       {
                         "Name": "f0",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 229,
                         "NameEnd": 231
                       },
                       {
                         "Name": "f1",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 232,
                         "NameEnd": 234
                       }
@@ -188,7 +188,7 @@
               "AliasPos": 236,
               "Alias": {
                 "Name": "f333",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 239,
                 "NameEnd": 243
               }
@@ -214,19 +214,19 @@
                   "Items": [
                     {
                       "Name": "f0",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 270,
                       "NameEnd": 272
                     },
                     {
                       "Name": "f1",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 273,
                       "NameEnd": 275
                     },
                     {
                       "Name": "f2",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 276,
                       "NameEnd": 278
                     },
@@ -235,7 +235,7 @@
                         "Function": {
                           "Name": {
                             "Name": "ROW_NUMBER",
-                            "Unquoted": false,
+                            "QuoteType": 1,
                             "NamePos": 289,
                             "NameEnd": 299
                           },
@@ -264,7 +264,7 @@
                               "Items": [
                                 {
                                   "Name": "f0",
-                                  "Unquoted": false,
+                                  "QuoteType": 1,
                                   "NamePos": 320,
                                   "NameEnd": 322
                                 }
@@ -280,7 +280,7 @@
                                 "Expr": {
                                   "Name": {
                                     "Name": "coalesce",
-                                    "Unquoted": false,
+                                    "QuoteType": 1,
                                     "NamePos": 332,
                                     "NameEnd": 340
                                   },
@@ -294,13 +294,13 @@
                                       "Items": [
                                         {
                                           "Name": "f1",
-                                          "Unquoted": false,
+                                          "QuoteType": 1,
                                           "NamePos": 341,
                                           "NameEnd": 343
                                         },
                                         {
                                           "Name": "f2",
-                                          "Unquoted": false,
+                                          "QuoteType": 1,
                                           "NamePos": 344,
                                           "NameEnd": 346
                                         }
@@ -319,7 +319,7 @@
                       "AliasPos": 349,
                       "Alias": {
                         "Name": "rn",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 352,
                         "NameEnd": 354
                       }
@@ -335,13 +335,13 @@
                     "Expr": {
                       "Database": {
                         "Name": "test",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 365,
                         "NameEnd": 369
                       },
                       "Table": {
                         "Name": "t",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 370,
                         "NameEnd": 371
                       }
@@ -358,7 +358,7 @@
                     "LeftExpr": {
                       "LeftExpr": {
                         "Name": "f3",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 383,
                         "NameEnd": 385
                       },
@@ -397,7 +397,7 @@
                     "RightExpr": {
                       "LeftExpr": {
                         "Name": "env",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 423,
                         "NameEnd": 426
                       },
@@ -428,7 +428,7 @@
               "AliasPos": 441,
               "Alias": {
                 "Name": "tmp",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 444,
                 "NameEnd": 447
               }
@@ -444,7 +444,7 @@
           "Expr": {
             "LeftExpr": {
               "Name": "rn",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 454,
               "NameEnd": 456
             },

--- a/parser/testdata/ddl/output/create_role.sql.golden.json
+++ b/parser/testdata/ddl/output/create_role.sql.golden.json
@@ -8,7 +8,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 34,
           "NameEnd": 42
         },
@@ -28,7 +28,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 56,
           "NameEnd": 64
         },
@@ -37,7 +37,7 @@
           "OnPos": 65,
           "Expr": {
             "Name": "cluster_1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 76,
             "NameEnd": 85
           }
@@ -56,7 +56,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 99,
           "NameEnd": 107
         },
@@ -66,7 +66,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 109,
           "NameEnd": 117
         },
@@ -86,7 +86,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 131,
           "NameEnd": 139
         },
@@ -95,7 +95,7 @@
           "OnPos": 140,
           "Expr": {
             "Name": "cluster_1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 151,
             "NameEnd": 160
           }
@@ -104,7 +104,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 162,
           "NameEnd": 170
         },
@@ -124,7 +124,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 184,
           "NameEnd": 192
         },
@@ -133,7 +133,7 @@
           "OnPos": 193,
           "Expr": {
             "Name": "cluster_1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 204,
             "NameEnd": 213
           }
@@ -142,7 +142,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 215,
           "NameEnd": 223
         },
@@ -151,7 +151,7 @@
           "OnPos": 224,
           "Expr": {
             "Name": "cluster_2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 235,
             "NameEnd": 244
           }
@@ -170,7 +170,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 258,
           "NameEnd": 266
         },
@@ -184,7 +184,7 @@
         "SettingPairs": [],
         "Modifier": {
           "Name": "NONE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 276,
           "NameEnd": 280
         }
@@ -200,7 +200,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 294,
           "NameEnd": 302
         },
@@ -215,7 +215,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 312,
               "NameEnd": 319
             },
@@ -239,7 +239,7 @@
       {
         "Name": {
           "Name": "r3_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 343,
           "NameEnd": 351
         },
@@ -254,7 +254,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 361,
               "NameEnd": 377
             },
@@ -279,7 +279,7 @@
       {
         "Name": {
           "Name": "r4_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 399,
           "NameEnd": 407
         },
@@ -294,7 +294,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 417,
               "NameEnd": 433
             },
@@ -303,7 +303,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 434,
               "NameEnd": 437
             },
@@ -328,7 +328,7 @@
       {
         "Name": {
           "Name": "r5_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 459,
           "NameEnd": 467
         },
@@ -343,7 +343,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 477,
               "NameEnd": 493
             },
@@ -352,7 +352,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 494,
               "NameEnd": 497
             },
@@ -377,7 +377,7 @@
       {
         "Name": {
           "Name": "r6_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 519,
           "NameEnd": 527
         },
@@ -392,7 +392,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 537,
               "NameEnd": 553
             },
@@ -401,7 +401,7 @@
         ],
         "Modifier": {
           "Name": "CONST",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 554,
           "NameEnd": 559
         }
@@ -417,7 +417,7 @@
       {
         "Name": {
           "Name": "r7_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 573,
           "NameEnd": 581
         },
@@ -432,7 +432,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 591,
               "NameEnd": 607
             },
@@ -441,7 +441,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 608,
           "NameEnd": 616
         }
@@ -457,7 +457,7 @@
       {
         "Name": {
           "Name": "r8_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 630,
           "NameEnd": 638
         },
@@ -472,7 +472,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 648,
               "NameEnd": 664
             },
@@ -486,7 +486,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 673,
               "NameEnd": 676
             },
@@ -500,7 +500,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 685,
               "NameEnd": 688
             },
@@ -514,7 +514,7 @@
         ],
         "Modifier": {
           "Name": "CONST",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 697,
           "NameEnd": 702
         }
@@ -530,7 +530,7 @@
       {
         "Name": {
           "Name": "r9_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 716,
           "NameEnd": 724
         },
@@ -545,7 +545,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 734,
               "NameEnd": 741
             },
@@ -563,7 +563,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 753,
               "NameEnd": 769
             },
@@ -577,7 +577,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 778,
           "NameEnd": 786
         }
@@ -593,7 +593,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 800,
           "NameEnd": 808
         },
@@ -603,7 +603,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 810,
           "NameEnd": 818
         },
@@ -623,7 +623,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 832,
           "NameEnd": 840
         },
@@ -638,7 +638,7 @@
           {
             "Name": {
               "Name": "readonly",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 850,
               "NameEnd": 858
             },
@@ -663,7 +663,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 874,
           "NameEnd": 882
         },
@@ -678,7 +678,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 892,
               "NameEnd": 899
             },
@@ -702,7 +702,7 @@
       {
         "Name": {
           "Name": "r3_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 923,
           "NameEnd": 931
         },
@@ -717,7 +717,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 941,
               "NameEnd": 957
             },
@@ -731,7 +731,7 @@
           {
             "Name": {
               "Name": "MIN",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 966,
               "NameEnd": 969
             },
@@ -745,7 +745,7 @@
           {
             "Name": {
               "Name": "MAX",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 978,
               "NameEnd": 981
             },
@@ -759,7 +759,7 @@
         ],
         "Modifier": {
           "Name": "WRITABLE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 990,
           "NameEnd": 998
         }
@@ -775,7 +775,7 @@
       {
         "Name": {
           "Name": "r4_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1012,
           "NameEnd": 1020
         },
@@ -790,7 +790,7 @@
           {
             "Name": {
               "Name": "PROFILE",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 1030,
               "NameEnd": 1037
             },
@@ -808,7 +808,7 @@
           {
             "Name": {
               "Name": "max_memory_usage",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 1049,
               "NameEnd": 1065
             },
@@ -827,7 +827,7 @@
           {
             "Name": {
               "Name": "readonly",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 1075,
               "NameEnd": 1083
             },
@@ -852,7 +852,7 @@
       {
         "Name": {
           "Name": "r5_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1099,
           "NameEnd": 1107
         },
@@ -866,7 +866,7 @@
         "SettingPairs": [],
         "Modifier": {
           "Name": "NONE",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1117,
           "NameEnd": 1121
         }
@@ -882,7 +882,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1135,
           "NameEnd": 1143
         },
@@ -906,7 +906,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 1161,
           "NameEnd": 1169
         },

--- a/parser/testdata/ddl/output/create_table_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_basic.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 149,
         "NameEnd": 153
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 154,
         "NameEnd": 166
       }
@@ -28,14 +28,14 @@
           "ColumnEnd": 182,
           "Name": {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 173,
             "NameEnd": 175
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 176,
               "NameEnd": 182
             }
@@ -53,14 +53,14 @@
           "ColumnEnd": 212,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 188,
             "NameEnd": 190
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 191,
               "NameEnd": 197
             }
@@ -73,7 +73,7 @@
             "RightParenPos": 212,
             "Name": {
               "Name": "ZSTD",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 204,
               "NameEnd": 208
             },
@@ -93,7 +93,7 @@
           "ColumnEnd": 232,
           "Name": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 218,
             "NameEnd": 220
           },
@@ -102,7 +102,7 @@
             "RightParenPos": 232,
             "Name": {
               "Name": "VARCHAR",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 221,
               "NameEnd": 228
             },
@@ -128,14 +128,14 @@
           "ColumnEnd": 250,
           "Name": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 239,
             "NameEnd": 241
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 242,
               "NameEnd": 250
             }
@@ -153,14 +153,14 @@
           "ColumnEnd": 267,
           "Name": {
             "Name": "f4",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 256,
             "NameEnd": 258
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 259,
               "NameEnd": 267
             }
@@ -178,7 +178,7 @@
           "ColumnEnd": 293,
           "Name": {
             "Name": "f5",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 273,
             "NameEnd": 275
           },
@@ -187,7 +187,7 @@
             "RightParenPos": 293,
             "Name": {
               "Name": "Map",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 276,
               "NameEnd": 279
             },
@@ -195,7 +195,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 280,
                   "NameEnd": 286
                 }
@@ -203,7 +203,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 287,
                   "NameEnd": 293
                 }
@@ -223,14 +223,14 @@
           "ColumnEnd": 309,
           "Name": {
             "Name": "f6",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 300,
             "NameEnd": 302
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 303,
               "NameEnd": 309
             }
@@ -248,7 +248,7 @@
           "ColumnEnd": 450,
           "Name": {
             "Name": "f7",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 315,
             "NameEnd": 317
           },
@@ -257,7 +257,7 @@
             "RightParenPos": 450,
             "Name": {
               "Name": "Nested",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 318,
               "NameEnd": 324
             },
@@ -267,14 +267,14 @@
                 "ColumnEnd": 345,
                 "Name": {
                   "Name": "f70",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 335,
                   "NameEnd": 338
                 },
                 "Type": {
                   "Name": {
                     "Name": "UInt32",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 339,
                     "NameEnd": 345
                   }
@@ -292,14 +292,14 @@
                 "ColumnEnd": 365,
                 "Name": {
                   "Name": "f71",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 355,
                   "NameEnd": 358
                 },
                 "Type": {
                   "Name": {
                     "Name": "UInt32",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 359,
                     "NameEnd": 365
                   }
@@ -317,14 +317,14 @@
                 "ColumnEnd": 387,
                 "Name": {
                   "Name": "f72",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 375,
                   "NameEnd": 378
                 },
                 "Type": {
                   "Name": {
                     "Name": "DateTime",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 379,
                     "NameEnd": 387
                   }
@@ -342,14 +342,14 @@
                 "ColumnEnd": 406,
                 "Name": {
                   "Name": "f73",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 397,
                   "NameEnd": 400
                 },
                 "Type": {
                   "Name": {
                     "Name": "Int64",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 401,
                     "NameEnd": 406
                   }
@@ -367,14 +367,14 @@
                 "ColumnEnd": 425,
                 "Name": {
                   "Name": "f74",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 416,
                   "NameEnd": 419
                 },
                 "Type": {
                   "Name": {
                     "Name": "Int64",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 420,
                     "NameEnd": 425
                   }
@@ -392,14 +392,14 @@
                 "ColumnEnd": 445,
                 "Name": {
                   "Name": "f75",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 435,
                   "NameEnd": 438
                 },
                 "Type": {
                   "Name": {
                     "Name": "String",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 439,
                     "NameEnd": 445
                   }
@@ -427,14 +427,14 @@
           "ColumnEnd": 481,
           "Name": {
             "Name": "f8",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 457,
             "NameEnd": 459
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 460,
               "NameEnd": 468
             }
@@ -446,7 +446,7 @@
             "Expr": {
               "Name": {
                 "Name": "now",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 477,
                 "NameEnd": 480
               },
@@ -489,19 +489,19 @@
             "Items": [
               {
                 "Name": "f0",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 517,
                 "NameEnd": 519
               },
               {
                 "Name": "f1",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 521,
                 "NameEnd": 523
               },
               {
                 "Name": "f2",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 525,
                 "NameEnd": 527
               }
@@ -520,7 +520,7 @@
             {
               "Name": {
                 "Name": "toYYYYMMDD",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 542,
                 "NameEnd": 552
               },
@@ -534,7 +534,7 @@
                   "Items": [
                     {
                       "Name": "f3",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 553,
                       "NameEnd": 555
                     }
@@ -556,7 +556,7 @@
             "Expr": {
               "LeftExpr": {
                 "Name": "f3",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 561,
                 "NameEnd": 563
               },
@@ -571,7 +571,7 @@
                 },
                 "Unit": {
                   "Name": "MONTH",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 577,
                   "NameEnd": 582
                 }
@@ -599,19 +599,19 @@
                 "Items": [
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 593,
                     "NameEnd": 595
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 596,
                     "NameEnd": 598
                   },
                   {
                     "Name": "f3",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 599,
                     "NameEnd": 601
                   }

--- a/parser/testdata/ddl/output/create_table_with_keyword_partition_by.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_keyword_partition_by.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 13,
         "NameEnd": 17
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 18,
         "NameEnd": 30
       }
@@ -34,14 +34,14 @@
           "ColumnEnd": 92,
           "Name": {
             "Name": "date",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 82,
             "NameEnd": 86
           },
           "Type": {
             "Name": {
               "Name": "Date",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 88,
               "NameEnd": 92
             }
@@ -59,14 +59,14 @@
           "ColumnEnd": 109,
           "Name": {
             "Name": "f1",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 99,
             "NameEnd": 101
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 103,
               "NameEnd": 109
             }
@@ -84,14 +84,14 @@
           "ColumnEnd": 126,
           "Name": {
             "Name": "f2",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 116,
             "NameEnd": 118
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 120,
               "NameEnd": 126
             }
@@ -109,14 +109,14 @@
           "ColumnEnd": 143,
           "Name": {
             "Name": "f3",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 133,
             "NameEnd": 135
           },
           "Type": {
             "Name": {
               "Name": "UInt64",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 137,
               "NameEnd": 143
             }
@@ -148,7 +148,7 @@
           "Items": [
             {
               "Name": "date",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 195,
               "NameEnd": 199
             }
@@ -165,7 +165,7 @@
             "SettingsPos": 235,
             "Name": {
               "Name": "index_granularity",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 235,
               "NameEnd": 252
             },
@@ -194,13 +194,13 @@
                 "Items": [
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 214,
                     "NameEnd": 216
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 218,
                     "NameEnd": 220
                   }

--- a/parser/testdata/ddl/output/create_table_with_nullable.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_nullable.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 13,
         "NameEnd": 17
       },
       "Table": {
         "Name": ".inner.752391fb-44cc-4dd5-b523-91fb44cc9dd5",
-        "Unquoted": true,
+        "QuoteType": 3,
         "NamePos": 19,
         "NameEnd": 62
       }
@@ -34,14 +34,14 @@
           "ColumnEnd": 129,
           "Name": {
             "Name": "f0",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 119,
             "NameEnd": 121
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 123,
               "NameEnd": 129
             }
@@ -59,14 +59,14 @@
           "ColumnEnd": 146,
           "Name": {
             "Name": "f1",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 136,
             "NameEnd": 138
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 140,
               "NameEnd": 146
             }
@@ -84,7 +84,7 @@
           "ColumnEnd": 178,
           "Name": {
             "Name": "f2",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 153,
             "NameEnd": 155
           },
@@ -93,7 +93,7 @@
             "RightParenPos": 178,
             "Name": {
               "Name": "LowCardinality",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 157,
               "NameEnd": 171
             },
@@ -101,7 +101,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 172,
                   "NameEnd": 178
                 }
@@ -121,7 +121,7 @@
           "ColumnEnd": 211,
           "Name": {
             "Name": "f3",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 186,
             "NameEnd": 188
           },
@@ -130,7 +130,7 @@
             "RightParenPos": 211,
             "Name": {
               "Name": "LowCardinality",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 190,
               "NameEnd": 204
             },
@@ -138,7 +138,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 205,
                   "NameEnd": 211
                 }
@@ -158,7 +158,7 @@
           "ColumnEnd": 235,
           "Name": {
             "Name": "f4",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 219,
             "NameEnd": 221
           },
@@ -167,7 +167,7 @@
             "RightParenPos": 235,
             "Name": {
               "Name": "DateTime64",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 223,
               "NameEnd": 233
             },
@@ -193,7 +193,7 @@
           "ColumnEnd": 269,
           "Name": {
             "Name": "f5",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 243,
             "NameEnd": 245
           },
@@ -202,7 +202,7 @@
             "RightParenPos": 269,
             "Name": {
               "Name": "Nullable",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 247,
               "NameEnd": 255
             },
@@ -212,7 +212,7 @@
                 "RightParenPos": 268,
                 "Name": {
                   "Name": "DateTime64",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 256,
                   "NameEnd": 266
                 },
@@ -240,7 +240,7 @@
           "ColumnEnd": 311,
           "Name": {
             "Name": "succeed_at",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 277,
             "NameEnd": 287
           },
@@ -249,7 +249,7 @@
             "RightParenPos": 311,
             "Name": {
               "Name": "Nullable",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 289,
               "NameEnd": 297
             },
@@ -259,7 +259,7 @@
                 "RightParenPos": 310,
                 "Name": {
                   "Name": "DateTime64",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 298,
                   "NameEnd": 308
                 },
@@ -303,7 +303,7 @@
               "LeftExpr": {
                 "Name": {
                   "Name": "xxHash32",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 347,
                   "NameEnd": 355
                 },
@@ -317,7 +317,7 @@
                     "Items": [
                       {
                         "Name": "tag_id",
-                        "Unquoted": false,
+                        "QuoteType": 1,
                         "NamePos": 356,
                         "NameEnd": 362
                       }
@@ -349,7 +349,7 @@
             "SettingsPos": 396,
             "Name": {
               "Name": "index_granularity",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 396,
               "NameEnd": 413
             },
@@ -370,7 +370,7 @@
             "OrderPos": 369,
             "Expr": {
               "Name": "label_id",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 378,
               "NameEnd": 386
             },

--- a/parser/testdata/ddl/output/create_table_with_on_clsuter.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_on_clsuter.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 27,
         "NameEnd": 31
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 32,
         "NameEnd": 44
       }
@@ -35,14 +35,14 @@
           "ColumnEnd": 89,
           "Name": {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 80,
             "NameEnd": 82
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 83,
               "NameEnd": 89
             }
@@ -60,14 +60,14 @@
           "ColumnEnd": 104,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 95,
             "NameEnd": 97
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 98,
               "NameEnd": 104
             }
@@ -85,14 +85,14 @@
           "ColumnEnd": 119,
           "Name": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 110,
             "NameEnd": 112
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 113,
               "NameEnd": 119
             }
@@ -110,14 +110,14 @@
           "ColumnEnd": 136,
           "Name": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 125,
             "NameEnd": 127
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 128,
               "NameEnd": 136
             }
@@ -135,14 +135,14 @@
           "ColumnEnd": 153,
           "Name": {
             "Name": "f4",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 142,
             "NameEnd": 144
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 145,
               "NameEnd": 153
             }
@@ -160,7 +160,7 @@
           "ColumnEnd": 179,
           "Name": {
             "Name": "f5",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 159,
             "NameEnd": 161
           },
@@ -169,7 +169,7 @@
             "RightParenPos": 179,
             "Name": {
               "Name": "Map",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 162,
               "NameEnd": 165
             },
@@ -177,7 +177,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 166,
                   "NameEnd": 172
                 }
@@ -185,7 +185,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 173,
                   "NameEnd": 179
                 }
@@ -205,14 +205,14 @@
           "ColumnEnd": 195,
           "Name": {
             "Name": "f6",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 186,
             "NameEnd": 188
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 189,
               "NameEnd": 195
             }
@@ -230,14 +230,14 @@
           "ColumnEnd": 225,
           "Name": {
             "Name": "f7",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 201,
             "NameEnd": 203
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 204,
               "NameEnd": 212
             }
@@ -249,7 +249,7 @@
             "Expr": {
               "Name": {
                 "Name": "now",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 221,
                 "NameEnd": 224
               },
@@ -312,7 +312,7 @@
             {
               "Name": {
                 "Name": "toYYYYMMDD",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 366,
                 "NameEnd": 376
               },
@@ -326,7 +326,7 @@
                   "Items": [
                     {
                       "Name": "f3",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 377,
                       "NameEnd": 379
                     }
@@ -348,7 +348,7 @@
             "Expr": {
               "LeftExpr": {
                 "Name": "f3",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 331,
                 "NameEnd": 333
               },
@@ -363,7 +363,7 @@
                 },
                 "Unit": {
                   "Name": "MONTH",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 347,
                   "NameEnd": 352
                 }
@@ -391,19 +391,19 @@
                 "Items": [
                   {
                     "Name": "f0",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 391,
                     "NameEnd": 393
                   },
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 394,
                     "NameEnd": 396
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 397,
                     "NameEnd": 399
                   }

--- a/parser/testdata/ddl/output/create_table_with_sample_by.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_sample_by.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "default",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 13,
         "NameEnd": 20
       },
       "Table": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 21,
         "NameEnd": 25
       }
@@ -34,14 +34,14 @@
           "ColumnEnd": 89,
           "Name": {
             "Name": "f0",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 77,
             "NameEnd": 79
           },
           "Type": {
             "Name": {
               "Name": "DateTime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 81,
               "NameEnd": 89
             }
@@ -59,14 +59,14 @@
           "ColumnEnd": 106,
           "Name": {
             "Name": "f1",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 96,
             "NameEnd": 98
           },
           "Type": {
             "Name": {
               "Name": "UInt32",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 100,
               "NameEnd": 106
             }
@@ -84,14 +84,14 @@
           "ColumnEnd": 123,
           "Name": {
             "Name": "f3",
-            "Unquoted": true,
+            "QuoteType": 3,
             "NamePos": 113,
             "NameEnd": 115
           },
           "Type": {
             "Name": {
               "Name": "UInt32",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 117,
               "NameEnd": 123
             }
@@ -145,7 +145,7 @@
             {
               "Name": {
                 "Name": "toYYYYMM",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 232,
                 "NameEnd": 240
               },
@@ -159,7 +159,7 @@
                   "Items": [
                     {
                       "Name": "timestamp",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 241,
                       "NameEnd": 250
                     }
@@ -175,7 +175,7 @@
         "SamplePos": 301,
         "Expr": {
           "Name": "userid",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 311,
           "NameEnd": 317
         }
@@ -189,7 +189,7 @@
             "SettingsPos": 327,
             "Name": {
               "Name": "index_granularity",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 327,
               "NameEnd": 344
             },
@@ -218,14 +218,14 @@
                 "Items": [
                   {
                     "Name": "contractid",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 262,
                     "NameEnd": 272
                   },
                   {
                     "Name": {
                       "Name": "toDate",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 274,
                       "NameEnd": 280
                     },
@@ -239,7 +239,7 @@
                         "Items": [
                           {
                             "Name": "timestamp",
-                            "Unquoted": false,
+                            "QuoteType": 1,
                             "NamePos": 281,
                             "NameEnd": 290
                           }
@@ -250,7 +250,7 @@
                   },
                   {
                     "Name": "userid",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 293,
                     "NameEnd": 299
                   }

--- a/parser/testdata/ddl/output/create_table_with_uuid.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_uuid.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 27,
         "NameEnd": 31
       },
       "Table": {
         "Name": "events_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 32,
         "NameEnd": 44
       }
@@ -41,14 +41,14 @@
           "ColumnEnd": 101,
           "Name": {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 92,
             "NameEnd": 94
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 95,
               "NameEnd": 101
             }
@@ -66,14 +66,14 @@
           "ColumnEnd": 116,
           "Name": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 107,
             "NameEnd": 109
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 110,
               "NameEnd": 116
             }
@@ -91,14 +91,14 @@
           "ColumnEnd": 131,
           "Name": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 122,
             "NameEnd": 124
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 125,
               "NameEnd": 131
             }
@@ -116,14 +116,14 @@
           "ColumnEnd": 148,
           "Name": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 137,
             "NameEnd": 139
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 140,
               "NameEnd": 148
             }
@@ -141,14 +141,14 @@
           "ColumnEnd": 165,
           "Name": {
             "Name": "f4",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 154,
             "NameEnd": 156
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 157,
               "NameEnd": 165
             }
@@ -166,7 +166,7 @@
           "ColumnEnd": 191,
           "Name": {
             "Name": "f5",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 171,
             "NameEnd": 173
           },
@@ -175,7 +175,7 @@
             "RightParenPos": 191,
             "Name": {
               "Name": "Map",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 174,
               "NameEnd": 177
             },
@@ -183,7 +183,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 178,
                   "NameEnd": 184
                 }
@@ -191,7 +191,7 @@
               {
                 "Name": {
                   "Name": "String",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 185,
                   "NameEnd": 191
                 }
@@ -211,14 +211,14 @@
           "ColumnEnd": 207,
           "Name": {
             "Name": "f6",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 198,
             "NameEnd": 200
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 201,
               "NameEnd": 207
             }
@@ -236,14 +236,14 @@
           "ColumnEnd": 237,
           "Name": {
             "Name": "f7",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 213,
             "NameEnd": 215
           },
           "Type": {
             "Name": {
               "Name": "Datetime",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 216,
               "NameEnd": 224
             }
@@ -255,7 +255,7 @@
             "Expr": {
               "Name": {
                 "Name": "now",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 233,
                 "NameEnd": 236
               },
@@ -318,7 +318,7 @@
             {
               "Name": {
                 "Name": "toYYYYMMDD",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 378,
                 "NameEnd": 388
               },
@@ -332,7 +332,7 @@
                   "Items": [
                     {
                       "Name": "f3",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 389,
                       "NameEnd": 391
                     }
@@ -354,7 +354,7 @@
             "Expr": {
               "LeftExpr": {
                 "Name": "f3",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 343,
                 "NameEnd": 345
               },
@@ -369,7 +369,7 @@
                 },
                 "Unit": {
                   "Name": "MONTH",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 359,
                   "NameEnd": 364
                 }
@@ -397,19 +397,19 @@
                 "Items": [
                   {
                     "Name": "f0",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 403,
                     "NameEnd": 405
                   },
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 406,
                     "NameEnd": 408
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 409,
                     "NameEnd": 411
                   }

--- a/parser/testdata/ddl/output/create_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_basic.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "my_view",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 26,
         "NameEnd": 33
       }
@@ -23,14 +23,14 @@
           "ColumnEnd": 45,
           "Name": {
             "Name": "col1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 34,
             "NameEnd": 38
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 39,
               "NameEnd": 45
             }
@@ -48,14 +48,14 @@
           "ColumnEnd": 58,
           "Name": {
             "Name": "col2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 47,
             "NameEnd": 51
           },
           "Type": {
             "Name": {
               "Name": "String",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 52,
               "NameEnd": 58
             }
@@ -86,13 +86,13 @@
           "Items": [
             {
               "Name": "id",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 74,
               "NameEnd": 76
             },
             {
               "Name": "name",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 82,
               "NameEnd": 86
             }
@@ -108,7 +108,7 @@
               "Database": null,
               "Table": {
                 "Name": "my_table",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 96,
                 "NameEnd": 104
               }

--- a/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
@@ -5,13 +5,13 @@
     "Name": {
       "Database": {
         "Name": "cluster_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 26,
         "NameEnd": 38
       },
       "Table": {
         "Name": "my_view",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 39,
         "NameEnd": 46
       }
@@ -47,13 +47,13 @@
           "Items": [
             {
               "Name": "column1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 151,
               "NameEnd": 158
             },
             {
               "Name": "column2",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 164,
               "NameEnd": 171
             }
@@ -69,7 +69,7 @@
               "Database": null,
               "Table": {
                 "Name": "my_other_table",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 185,
                 "NameEnd": 199
               }

--- a/parser/testdata/ddl/output/drop_database.sql.golden.json
+++ b/parser/testdata/ddl/output/drop_database.sql.golden.json
@@ -4,7 +4,7 @@
     "StatementEnd": 36,
     "Name": {
       "Name": "datbase_name",
-      "Unquoted": false,
+      "QuoteType": 1,
       "NamePos": 24,
       "NameEnd": 36
     },

--- a/parser/testdata/ddl/output/drop_role.sql.golden.json
+++ b/parser/testdata/ddl/output/drop_role.sql.golden.json
@@ -7,7 +7,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 20,
           "NameEnd": 28
         },
@@ -17,7 +17,7 @@
       {
         "Name": {
           "Name": "r2_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 30,
           "NameEnd": 38
         },
@@ -27,7 +27,7 @@
       {
         "Name": {
           "Name": "r3_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 40,
           "NameEnd": 48
         },
@@ -37,7 +37,7 @@
       {
         "Name": {
           "Name": "r4_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 50,
           "NameEnd": 58
         },
@@ -47,7 +47,7 @@
       {
         "Name": {
           "Name": "r5_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 60,
           "NameEnd": 68
         },
@@ -57,7 +57,7 @@
       {
         "Name": {
           "Name": "r6_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 70,
           "NameEnd": 78
         },
@@ -67,7 +67,7 @@
       {
         "Name": {
           "Name": "r7_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 80,
           "NameEnd": 88
         },
@@ -77,7 +77,7 @@
       {
         "Name": {
           "Name": "r8_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 90,
           "NameEnd": 98
         },
@@ -87,7 +87,7 @@
       {
         "Name": {
           "Name": "r9_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 100,
           "NameEnd": 108
         },
@@ -107,7 +107,7 @@
       {
         "Name": {
           "Name": "r2_01293_renamed",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 130,
           "NameEnd": 146
         },
@@ -127,7 +127,7 @@
       {
         "Name": {
           "Name": "r1_01293",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 168,
           "NameEnd": 176
         },

--- a/parser/testdata/ddl/output/drop_table_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/drop_table_basic.sql.golden.json
@@ -6,13 +6,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 21,
         "NameEnd": 25
       },
       "Table": {
         "Name": "table_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 26,
         "NameEnd": 36
       }

--- a/parser/testdata/ddl/output/drop_table_with_no_delay.sql.golden.json
+++ b/parser/testdata/ddl/output/drop_table_with_no_delay.sql.golden.json
@@ -6,13 +6,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 21,
         "NameEnd": 25
       },
       "Table": {
         "Name": "table_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 26,
         "NameEnd": 36
       }

--- a/parser/testdata/ddl/output/drop_table_with_on_clsuter.sql.golden.json
+++ b/parser/testdata/ddl/output/drop_table_with_on_clsuter.sql.golden.json
@@ -6,13 +6,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 21,
         "NameEnd": 25
       },
       "Table": {
         "Name": "table_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 26,
         "NameEnd": 36
       }

--- a/parser/testdata/ddl/output/grant_privilege.sql.golden.json
+++ b/parser/testdata/ddl/output/grant_privilege.sql.golden.json
@@ -20,13 +20,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 13,
                 "NameEnd": 14
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 15,
                 "NameEnd": 16
               }
@@ -39,13 +39,13 @@
     "On": {
       "Database": {
         "Name": "db",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 21,
         "NameEnd": 23
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 24,
         "NameEnd": 29
       }
@@ -53,7 +53,7 @@
     "To": [
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 33,
         "NameEnd": 37
       }
@@ -81,13 +81,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 52,
                 "NameEnd": 53
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 54,
                 "NameEnd": 55
               }
@@ -100,13 +100,13 @@
     "On": {
       "Database": {
         "Name": "db",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 60,
         "NameEnd": 62
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 63,
         "NameEnd": 68
       }
@@ -114,7 +114,7 @@
     "To": [
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 72,
         "NameEnd": 76
       }
@@ -145,13 +145,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 127,
                 "NameEnd": 128
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 129,
                 "NameEnd": 130
               }
@@ -164,13 +164,13 @@
     "On": {
       "Database": {
         "Name": "db",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 135,
         "NameEnd": 137
       },
       "Table": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 138,
         "NameEnd": 139
       }
@@ -178,7 +178,7 @@
     "To": [
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 143,
         "NameEnd": 147
       }
@@ -206,13 +206,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 162,
                 "NameEnd": 163
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 164,
                 "NameEnd": 165
               }
@@ -225,13 +225,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 170,
         "NameEnd": 171
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 172,
         "NameEnd": 177
       }
@@ -239,7 +239,7 @@
     "To": [
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 181,
         "NameEnd": 185
       }
@@ -267,13 +267,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 200,
                 "NameEnd": 201
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 202,
                 "NameEnd": 203
               }
@@ -286,13 +286,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 208,
         "NameEnd": 209
       },
       "Table": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 210,
         "NameEnd": 211
       }
@@ -300,7 +300,7 @@
     "To": [
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 215,
         "NameEnd": 219
       }
@@ -328,13 +328,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 234,
                 "NameEnd": 235
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 236,
                 "NameEnd": 237
               }
@@ -347,13 +347,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 242,
         "NameEnd": 243
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 244,
         "NameEnd": 249
       }
@@ -361,7 +361,7 @@
     "To": [
       {
         "Name": "CURRENT_USER",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 253,
         "NameEnd": 265
       }
@@ -389,13 +389,13 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 280,
                 "NameEnd": 281
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 282,
                 "NameEnd": 283
               }
@@ -408,13 +408,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 288,
         "NameEnd": 289
       },
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 290,
         "NameEnd": 295
       }
@@ -422,19 +422,19 @@
     "To": [
       {
         "Name": "CURRENT_USER",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 299,
         "NameEnd": 311
       },
       {
         "Name": "john",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 312,
         "NameEnd": 316
       },
       {
         "Name": "mary",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 317,
         "NameEnd": 321
       }
@@ -458,13 +458,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 336,
         "NameEnd": 337
       },
       "Table": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 338,
         "NameEnd": 339
       }
@@ -472,7 +472,7 @@
     "To": [
       {
         "Name": "admin_role",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 343,
         "NameEnd": 353
       }
@@ -506,13 +506,13 @@
     "On": {
       "Database": {
         "Name": "database",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 396,
         "NameEnd": 404
       },
       "Table": {
         "Name": "table_1",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 405,
         "NameEnd": 412
       }
@@ -520,7 +520,7 @@
     "To": [
       {
         "Name": "table_1_select_role",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 416,
         "NameEnd": 435
       }
@@ -548,19 +548,19 @@
             "Items": [
               {
                 "Name": "x",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 450,
                 "NameEnd": 451
               },
               {
                 "Name": "y",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 453,
                 "NameEnd": 454
               },
               {
                 "Name": "z",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 456,
                 "NameEnd": 457
               }
@@ -581,13 +581,13 @@
     "On": {
       "Database": {
         "Name": "database",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 469,
         "NameEnd": 477
       },
       "Table": {
         "Name": "table_1",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 478,
         "NameEnd": 485
       }
@@ -595,7 +595,7 @@
     "To": [
       {
         "Name": "table_1_select_role",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 489,
         "NameEnd": 508
       }
@@ -627,13 +627,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 535,
         "NameEnd": 536
       },
       "Table": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 537,
         "NameEnd": 538
       }
@@ -641,7 +641,7 @@
     "To": [
       {
         "Name": "select_all_role",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 543,
         "NameEnd": 558
       }
@@ -666,13 +666,13 @@
     "On": {
       "Database": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 582,
         "NameEnd": 583
       },
       "Table": {
         "Name": "*",
-        "Unquoted": false,
+        "QuoteType": 0,
         "NamePos": 584,
         "NameEnd": 585
       }
@@ -680,7 +680,7 @@
     "To": [
       {
         "Name": "select_all_role",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 590,
         "NameEnd": 605
       }

--- a/parser/testdata/ddl/output/optimize.sql.golden.json
+++ b/parser/testdata/ddl/output/optimize.sql.golden.json
@@ -6,7 +6,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 15,
         "NameEnd": 20
       }
@@ -27,7 +27,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 64,
         "NameEnd": 69
       }
@@ -44,7 +44,7 @@
         "Items": [
           {
             "Name": "*",
-            "Unquoted": false,
+            "QuoteType": 0,
             "NamePos": 85,
             "NameEnd": 85
           }
@@ -60,7 +60,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 146,
         "NameEnd": 151
       }
@@ -77,19 +77,19 @@
         "Items": [
           {
             "Name": "colX",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 167,
             "NameEnd": 171
           },
           {
             "Name": "colY",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 172,
             "NameEnd": 176
           },
           {
             "Name": "colZ",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 177,
             "NameEnd": 181
           }
@@ -105,7 +105,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 198,
         "NameEnd": 203
       }
@@ -122,7 +122,7 @@
         "Items": [
           {
             "Name": "*",
-            "Unquoted": false,
+            "QuoteType": 0,
             "NamePos": 219,
             "NameEnd": 219
           }
@@ -135,7 +135,7 @@
         "Items": [
           {
             "Name": "colX",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 228,
             "NameEnd": 232
           }
@@ -150,7 +150,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 249,
         "NameEnd": 254
       }
@@ -167,7 +167,7 @@
         "Items": [
           {
             "Name": "*",
-            "Unquoted": false,
+            "QuoteType": 0,
             "NamePos": 270,
             "NameEnd": 270
           }
@@ -188,13 +188,13 @@
               "Items": [
                 {
                   "Name": "colX",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 280,
                   "NameEnd": 284
                 },
                 {
                   "Name": "colY",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 286,
                   "NameEnd": 290
                 }
@@ -213,7 +213,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 308,
         "NameEnd": 313
       }
@@ -231,7 +231,7 @@
           {
             "Name": {
               "Name": "COLUMNS",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 329,
               "NameEnd": 336
             },
@@ -265,7 +265,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 380,
         "NameEnd": 385
       }
@@ -283,7 +283,7 @@
           {
             "Name": {
               "Name": "COLUMNS",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 401,
               "NameEnd": 408
             },
@@ -314,7 +314,7 @@
         "Items": [
           {
             "Name": "colX",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 443,
             "NameEnd": 447
           }
@@ -329,7 +329,7 @@
       "Database": null,
       "Table": {
         "Name": "table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 464,
         "NameEnd": 469
       }
@@ -347,7 +347,7 @@
           {
             "Name": {
               "Name": "COLUMNS",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 485,
               "NameEnd": 492
             },
@@ -386,13 +386,13 @@
               "Items": [
                 {
                   "Name": "colX",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 528,
                   "NameEnd": 532
                 },
                 {
                   "Name": "colY",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 534,
                   "NameEnd": 538
                 }

--- a/parser/testdata/ddl/output/rename.sql.golden.json
+++ b/parser/testdata/ddl/output/rename.sql.golden.json
@@ -9,7 +9,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 29,
             "NameEnd": 31
           }
@@ -18,7 +18,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 35,
             "NameEnd": 38
           }
@@ -37,7 +37,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 53,
             "NameEnd": 55
           }
@@ -46,7 +46,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 59,
             "NameEnd": 62
           }
@@ -72,7 +72,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 106,
             "NameEnd": 108
           }
@@ -81,7 +81,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 112,
             "NameEnd": 115
           }
@@ -92,7 +92,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 117,
             "NameEnd": 119
           }
@@ -101,7 +101,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 123,
             "NameEnd": 126
           }
@@ -120,7 +120,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 141,
             "NameEnd": 143
           }
@@ -129,7 +129,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 147,
             "NameEnd": 150
           }
@@ -140,7 +140,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 152,
             "NameEnd": 154
           }
@@ -149,7 +149,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 158,
             "NameEnd": 161
           }
@@ -175,7 +175,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 234,
             "NameEnd": 236
           }
@@ -184,7 +184,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 240,
             "NameEnd": 243
           }
@@ -203,7 +203,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 263,
             "NameEnd": 265
           }
@@ -212,7 +212,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 269,
             "NameEnd": 272
           }
@@ -238,7 +238,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 321,
             "NameEnd": 323
           }
@@ -247,7 +247,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 327,
             "NameEnd": 330
           }
@@ -258,7 +258,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 332,
             "NameEnd": 334
           }
@@ -267,7 +267,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 338,
             "NameEnd": 341
           }
@@ -286,7 +286,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 361,
             "NameEnd": 363
           }
@@ -295,7 +295,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 367,
             "NameEnd": 370
           }
@@ -306,7 +306,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 372,
             "NameEnd": 374
           }
@@ -315,7 +315,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 378,
             "NameEnd": 381
           }
@@ -341,7 +341,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 447,
             "NameEnd": 449
           }
@@ -350,7 +350,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 453,
             "NameEnd": 456
           }
@@ -369,7 +369,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 474,
             "NameEnd": 476
           }
@@ -378,7 +378,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 480,
             "NameEnd": 483
           }
@@ -404,7 +404,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 530,
             "NameEnd": 532
           }
@@ -413,7 +413,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 536,
             "NameEnd": 539
           }
@@ -424,7 +424,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 541,
             "NameEnd": 543
           }
@@ -433,7 +433,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 547,
             "NameEnd": 550
           }
@@ -452,7 +452,7 @@
           "Database": null,
           "Table": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 568,
             "NameEnd": 570
           }
@@ -461,7 +461,7 @@
           "Database": null,
           "Table": {
             "Name": "t11",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 574,
             "NameEnd": 577
           }
@@ -472,7 +472,7 @@
           "Database": null,
           "Table": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 579,
             "NameEnd": 581
           }
@@ -481,7 +481,7 @@
           "Database": null,
           "Table": {
             "Name": "t22",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 585,
             "NameEnd": 588
           }

--- a/parser/testdata/ddl/output/truncate_table_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/truncate_table_basic.sql.golden.json
@@ -7,13 +7,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 25,
         "NameEnd": 29
       },
       "Table": {
         "Name": "table_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 30,
         "NameEnd": 40
       }

--- a/parser/testdata/ddl/output/truncate_temporary_table_on_clsuter.sql.golden.json
+++ b/parser/testdata/ddl/output/truncate_temporary_table_on_clsuter.sql.golden.json
@@ -7,13 +7,13 @@
     "Name": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 35,
         "NameEnd": 39
       },
       "Table": {
         "Name": "table_name",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 40,
         "NameEnd": 50
       }

--- a/parser/testdata/dml/output/alter_table_with_modify_remove_ttl.sql.golden.json
+++ b/parser/testdata/dml/output/alter_table_with_modify_remove_ttl.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "infra",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 17
       },
       "Table": {
         "Name": "flow_processed_emails_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 18,
         "NameEnd": 45
       }
@@ -20,7 +20,7 @@
       "OnPos": 46,
       "Expr": {
         "Name": "default_cluster",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 57,
         "NameEnd": 72
       }

--- a/parser/testdata/dml/output/alter_table_with_modify_ttl.sql.golden.json
+++ b/parser/testdata/dml/output/alter_table_with_modify_ttl.sql.golden.json
@@ -5,13 +5,13 @@
     "TableIdentifier": {
       "Database": {
         "Name": "infra",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 17
       },
       "Table": {
         "Name": "flow_processed_emails_local",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 18,
         "NameEnd": 45
       }
@@ -20,7 +20,7 @@
       "OnPos": 46,
       "Expr": {
         "Name": "default_cluster",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 57,
         "NameEnd": 72
       }
@@ -34,7 +34,7 @@
           "Expr": {
             "LeftExpr": {
               "Name": "created_at",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 84,
               "NameEnd": 94
             },
@@ -49,7 +49,7 @@
               },
               "Unit": {
                 "Name": "YEAR",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 108,
                 "NameEnd": 112
               }

--- a/parser/testdata/dml/output/delete_from.sql.golden.json
+++ b/parser/testdata/dml/output/delete_from.sql.golden.json
@@ -5,7 +5,7 @@
       "Database": null,
       "Table": {
         "Name": "hits",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       }
@@ -14,7 +14,7 @@
     "WhereExpr": {
       "LeftExpr": {
         "Name": "Title",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 23,
         "NameEnd": 28
       },

--- a/parser/testdata/dml/output/insert_values.sql.golden.json
+++ b/parser/testdata/dml/output/insert_values.sql.golden.json
@@ -5,13 +5,13 @@
     "Table": {
       "Database": {
         "Name": "helloworld",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 22
       },
       "Table": {
         "Name": "my_first_table",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 23,
         "NameEnd": 37
       }
@@ -23,7 +23,7 @@
         {
           "Ident": {
             "Name": "user_id",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 39,
             "NameEnd": 46
           },
@@ -32,7 +32,7 @@
         {
           "Ident": {
             "Name": "message",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 48,
             "NameEnd": 55
           },
@@ -41,7 +41,7 @@
         {
           "Ident": {
             "Name": "timestamp",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 57,
             "NameEnd": 66
           },
@@ -68,7 +68,7 @@
           {
             "Name": {
               "Name": "now",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 147,
               "NameEnd": 150
             },
@@ -110,7 +110,7 @@
           {
             "Name": {
               "Name": "yesterday",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 235,
               "NameEnd": 244
             },
@@ -152,7 +152,7 @@
           {
             "Name": {
               "Name": "today",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 323,
               "NameEnd": 328
             },
@@ -195,7 +195,7 @@
             "LeftExpr": {
               "Name": {
                 "Name": "now",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 411,
                 "NameEnd": 414
               },

--- a/parser/testdata/dml/output/insert_with_select.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_select.sql.golden.json
@@ -5,13 +5,13 @@
     "Table": {
       "Database": {
         "Name": "test",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 12,
         "NameEnd": 16
       },
       "Table": {
         "Name": "visits_null",
-        "Unquoted": false,
+        "QuoteType": 1,
         "NamePos": 17,
         "NameEnd": 28
       }
@@ -30,25 +30,25 @@
         "Items": [
           {
             "Name": "CounterID",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 40,
             "NameEnd": 49
           },
           {
             "Name": "StartDate",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 55,
             "NameEnd": 64
           },
           {
             "Name": "Sign",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 70,
             "NameEnd": 74
           },
           {
             "Name": "UserID",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 80,
             "NameEnd": 86
           }
@@ -63,13 +63,13 @@
           "Expr": {
             "Database": {
               "Name": "test",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 92,
               "NameEnd": 96
             },
             "Table": {
               "Name": "visits",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 97,
               "NameEnd": 103
             }

--- a/parser/testdata/query/format/select_column_alias_string.sql
+++ b/parser/testdata/query/format/select_column_alias_string.sql
@@ -4,4 +4,4 @@ SELECT 'abc' as "value2";
 -- Format SQL:
 
 SELECT 
-  'abc' AS 'value2';
+  'abc' AS "value2";

--- a/parser/testdata/query/format/select_simple_with_bracket.sql
+++ b/parser/testdata/query/format/select_simple_with_bracket.sql
@@ -6,4 +6,4 @@ SELECT arrayConcat([1, 2], [3, 4], [5, 6]) AS res, f1["abc"] as f2
 
 SELECT 
   arrayConcat([1, 2], [3, 4], [5, 6]) AS res,
-  f1['abc'] AS f2;
+  f1["abc"] AS f2;

--- a/parser/testdata/query/format/select_with_join_only.sql
+++ b/parser/testdata/query/format/select_with_join_only.sql
@@ -7,4 +7,4 @@ SELECT * FROM "t1" JOIN "t2" ON true
 SELECT 
   *
 FROM
-  't1' JOIN 't2' ON true;
+  "t1" JOIN "t2" ON true;

--- a/parser/testdata/query/format/select_with_literal_table_name.sql
+++ b/parser/testdata/query/format/select_with_literal_table_name.sql
@@ -7,5 +7,5 @@ select table_name from "information_schema"."tables" limit 1;
 SELECT 
   table_name
 FROM
-  'information_schema'.'tables'
+  "information_schema"."tables"
 LIMIT 1;

--- a/parser/testdata/query/format/select_with_string_expr.sql
+++ b/parser/testdata/query/format/select_with_string_expr.sql
@@ -4,10 +4,10 @@ WITH "abc" AS (SELECT 1 AS a) SELECT * FROM "abc"
 
 -- Format SQL:
 WITH
-  'abc' AS (
+  "abc" AS (
     SELECT 
       1 AS a)
 SELECT 
   *
 FROM
-  'abc';
+  "abc";

--- a/parser/testdata/query/output/select_cast.sql.golden.json
+++ b/parser/testdata/query/output/select_cast.sql.golden.json
@@ -23,7 +23,7 @@
             "AsType": {
               "Name": {
                 "Name": "Float64",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 17,
                 "NameEnd": 24
               }
@@ -32,7 +32,7 @@
           "AliasPos": 26,
           "Alias": {
             "Name": "value",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 29,
             "NameEnd": 34
           }
@@ -85,7 +85,7 @@
           "AliasPos": 62,
           "Alias": {
             "Name": "value",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 65,
             "NameEnd": 70
           }
@@ -137,7 +137,7 @@
                   "AliasPos": 82,
                   "Alias": {
                     "Name": "Float64",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 85,
                     "NameEnd": 92
                   }
@@ -149,7 +149,7 @@
           "AliasPos": 94,
           "Alias": {
             "Name": "value",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 97,
             "NameEnd": 102
           }
@@ -193,7 +193,7 @@
             "Operation": "::",
             "RightExpr": {
               "Name": "Float64",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 114,
               "NameEnd": 121
             },
@@ -203,7 +203,7 @@
           "AliasPos": 122,
           "Alias": {
             "Name": "value",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 125,
             "NameEnd": 130
           }

--- a/parser/testdata/query/output/select_column_alias_string.sql.golden.json
+++ b/parser/testdata/query/output/select_column_alias_string.sql.golden.json
@@ -17,9 +17,10 @@
           },
           "AliasPos": 13,
           "Alias": {
-            "LiteralPos": 17,
-            "LiteralEnd": 23,
-            "Literal": "value2"
+            "Name": "value2",
+            "QuoteType": 2,
+            "NamePos": 17,
+            "NameEnd": 23
           }
         }
       ]

--- a/parser/testdata/query/output/select_simple.sql.golden.json
+++ b/parser/testdata/query/output/select_simple.sql.golden.json
@@ -11,7 +11,7 @@
       "Items": [
         {
           "Name": "f0",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 11,
           "NameEnd": 13
         },
@@ -19,7 +19,7 @@
           "Expr": {
             "Name": {
               "Name": "coalesce",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 15,
               "NameEnd": 23
             },
@@ -33,13 +33,13 @@
                 "Items": [
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 24,
                     "NameEnd": 26
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 28,
                     "NameEnd": 30
                   }
@@ -51,7 +51,7 @@
           "AliasPos": 32,
           "Alias": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 35,
             "NameEnd": 37
           }
@@ -61,7 +61,7 @@
             "Function": {
               "Name": {
                 "Name": "row_number",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 39,
                 "NameEnd": 49
               },
@@ -90,7 +90,7 @@
                   "Items": [
                     {
                       "Name": "f0",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 71,
                       "NameEnd": 73
                     }
@@ -105,7 +105,7 @@
                     "OrderPos": 74,
                     "Expr": {
                       "Name": "f1",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 83,
                       "NameEnd": 85
                     },
@@ -119,7 +119,7 @@
           "AliasPos": 91,
           "Alias": {
             "Name": "rn",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 94,
             "NameEnd": 96
           }
@@ -135,13 +135,13 @@
         "Expr": {
           "Database": {
             "Name": "test",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 102,
             "NameEnd": 106
           },
           "Table": {
             "Name": "events_local",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 107,
             "NameEnd": 119
           }
@@ -168,7 +168,7 @@
                   {
                     "LeftExpr": {
                       "Name": "f0",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 127,
                       "NameEnd": 129
                     },
@@ -219,7 +219,7 @@
                   {
                     "LeftExpr": {
                       "Name": "f1",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 162,
                       "NameEnd": 164
                     },
@@ -251,7 +251,7 @@
                 {
                   "LeftExpr": {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 183,
                     "NameEnd": 185
                   },
@@ -275,7 +275,7 @@
         "RightExpr": {
           "LeftExpr": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 211,
             "NameEnd": 213
           },
@@ -324,13 +324,13 @@
         "Items": [
           {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 248,
             "NameEnd": 250
           },
           {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 254,
             "NameEnd": 256
           }
@@ -366,7 +366,7 @@
         "Items": [
           {
             "Name": "f0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 275,
             "NameEnd": 277
           }

--- a/parser/testdata/query/output/select_simple_with_bracket.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_bracket.sql.golden.json
@@ -13,7 +13,7 @@
           "Expr": {
             "Name": {
               "Name": "arrayConcat",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 7,
               "NameEnd": 18
             },
@@ -102,7 +102,7 @@
           "AliasPos": 43,
           "Alias": {
             "Name": "res",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 46,
             "NameEnd": 49
           }
@@ -111,7 +111,7 @@
           "Expr": {
             "Object": {
               "Name": "f1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 51,
               "NameEnd": 53
             },
@@ -124,9 +124,10 @@
                 "HasDistinct": false,
                 "Items": [
                   {
-                    "LiteralPos": 55,
-                    "LiteralEnd": 58,
-                    "Literal": "abc"
+                    "Name": "abc",
+                    "QuoteType": 2,
+                    "NamePos": 55,
+                    "NameEnd": 58
                   }
                 ]
               }
@@ -135,7 +136,7 @@
           "AliasPos": 61,
           "Alias": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 64,
             "NameEnd": 66
           }

--- a/parser/testdata/query/output/select_simple_with_cte_with_column_aliases.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_cte_with_column_aliases.sql.golden.json
@@ -11,7 +11,7 @@
           "Expr": {
             "Name": {
               "Name": "test",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 9,
               "NameEnd": 13
             },
@@ -25,19 +25,19 @@
                 "Items": [
                   {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 14,
                     "NameEnd": 16
                   },
                   {
                     "Name": "f2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 18,
                     "NameEnd": 20
                   },
                   {
                     "Name": "f3",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 22,
                     "NameEnd": 24
                   }
@@ -58,19 +58,19 @@
               "Items": [
                 {
                   "Name": "f4",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 37,
                   "NameEnd": 39
                 },
                 {
                   "Name": "f5",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 41,
                   "NameEnd": 43
                 },
                 {
                   "Name": "f6",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 45,
                   "NameEnd": 47
                 }
@@ -86,7 +86,7 @@
                   "Database": null,
                   "Table": {
                     "Name": "sales",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 53,
                     "NameEnd": 58
                   }
@@ -121,14 +121,14 @@
         {
           "Expr": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 71,
             "NameEnd": 73
           },
           "AliasPos": 74,
           "Alias": {
             "Name": "new_f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 77,
             "NameEnd": 83
           }
@@ -136,14 +136,14 @@
         {
           "Expr": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 89,
             "NameEnd": 91
           },
           "AliasPos": 92,
           "Alias": {
             "Name": "new_f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 95,
             "NameEnd": 101
           }
@@ -151,14 +151,14 @@
         {
           "Expr": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 107,
             "NameEnd": 109
           },
           "AliasPos": 110,
           "Alias": {
             "Name": "new_f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 113,
             "NameEnd": 119
           }
@@ -175,7 +175,7 @@
           "Database": null,
           "Table": {
             "Name": "test",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 129,
             "NameEnd": 133
           }

--- a/parser/testdata/query/output/select_simple_with_group_by_with_cube_totals.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_group_by_with_cube_totals.sql.golden.json
@@ -11,14 +11,14 @@
       "Items": [
         {
           "Name": "a",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 7,
           "NameEnd": 8
         },
         {
           "Name": {
             "Name": "COUNT",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 10,
             "NameEnd": 15
           },
@@ -32,7 +32,7 @@
               "Items": [
                 {
                   "Name": "b",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 16,
                   "NameEnd": 17
                 }
@@ -53,7 +53,7 @@
           "Database": null,
           "Table": {
             "Name": "group_by_all",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 24,
             "NameEnd": 36
           }
@@ -78,7 +78,7 @@
           "Items": [
             {
               "Name": "a",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 51,
               "NameEnd": 52
             }
@@ -100,7 +100,7 @@
           "OrderPos": 76,
           "Expr": {
             "Name": "a",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 85,
             "NameEnd": 86
           },

--- a/parser/testdata/query/output/select_simple_with_is_not_null.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_is_not_null.sql.golden.json
@@ -11,33 +11,33 @@
       "Items": [
         {
           "Name": "f0",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 7,
           "NameEnd": 9
         },
         {
           "Name": "f1",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 10,
           "NameEnd": 12
         },
         {
           "Name": "f2",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 13,
           "NameEnd": 15
         },
         {
           "Expr": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 16,
             "NameEnd": 18
           },
           "AliasPos": 19,
           "Alias": {
             "Name": "a0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 22,
             "NameEnd": 24
           }
@@ -53,13 +53,13 @@
         "Expr": {
           "Database": {
             "Name": "test",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 30,
             "NameEnd": 34
           },
           "Table": {
             "Name": "events_local",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 35,
             "NameEnd": 47
           }
@@ -86,7 +86,7 @@
                   {
                     "LeftExpr": {
                       "Name": "f0",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 55,
                       "NameEnd": 57
                     },
@@ -137,7 +137,7 @@
                   {
                     "LeftExpr": {
                       "Name": "f1",
-                      "Unquoted": false,
+                      "QuoteType": 1,
                       "NamePos": 92,
                       "NameEnd": 94
                     },
@@ -162,7 +162,7 @@
             "IsPos": 114,
             "Expr": {
               "Name": "f2",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 114,
               "NameEnd": 116
             }
@@ -175,7 +175,7 @@
           "IsPos": 131,
           "Expr": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 131,
             "NameEnd": 133
           }

--- a/parser/testdata/query/output/select_simple_with_is_null.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_is_null.sql.golden.json
@@ -11,33 +11,33 @@
       "Items": [
         {
           "Name": "f0",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 7,
           "NameEnd": 9
         },
         {
           "Name": "f1",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 10,
           "NameEnd": 12
         },
         {
           "Name": "f2",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 13,
           "NameEnd": 15
         },
         {
           "Expr": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 16,
             "NameEnd": 18
           },
           "AliasPos": 19,
           "Alias": {
             "Name": "a0",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 22,
             "NameEnd": 24
           }
@@ -53,13 +53,13 @@
         "Expr": {
           "Database": {
             "Name": "test",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 30,
             "NameEnd": 34
           },
           "Table": {
             "Name": "events_local",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 35,
             "NameEnd": 47
           }
@@ -85,7 +85,7 @@
                 {
                   "LeftExpr": {
                     "Name": "f0",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 55,
                     "NameEnd": 57
                   },
@@ -136,7 +136,7 @@
                 {
                   "LeftExpr": {
                     "Name": "f1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 90,
                     "NameEnd": 92
                   },
@@ -161,7 +161,7 @@
           "IsPos": 110,
           "Expr": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 110,
             "NameEnd": 112
           }

--- a/parser/testdata/query/output/select_simple_with_top_clause.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_top_clause.sql.golden.json
@@ -21,7 +21,7 @@
       "Items": [
         {
           "Name": "my_column",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 14,
           "NameEnd": 23
         }
@@ -37,7 +37,7 @@
           "Database": null,
           "Table": {
             "Name": "tableName",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 29,
             "NameEnd": 38
           }

--- a/parser/testdata/query/output/select_simple_with_with_clause.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_with_clause.sql.golden.json
@@ -10,7 +10,7 @@
           "CTEPos": 9,
           "Expr": {
             "Name": "cte1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 9,
             "NameEnd": 13
           },
@@ -26,7 +26,7 @@
               "Items": [
                 {
                   "Name": "f1",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 25,
                   "NameEnd": 27
                 }
@@ -42,7 +42,7 @@
                   "Database": null,
                   "Table": {
                     "Name": "t1",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 33,
                     "NameEnd": 35
                   }
@@ -70,7 +70,7 @@
           "CTEPos": 42,
           "Expr": {
             "Name": "cte2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 42,
             "NameEnd": 46
           },
@@ -86,7 +86,7 @@
               "Items": [
                 {
                   "Name": "f2",
-                  "Unquoted": false,
+                  "QuoteType": 1,
                   "NamePos": 58,
                   "NameEnd": 60
                 }
@@ -102,7 +102,7 @@
                   "Database": null,
                   "Table": {
                     "Name": "t2",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 66,
                     "NameEnd": 68
                   }
@@ -138,13 +138,13 @@
           "Database": null,
           "Table": {
             "Name": "cte1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 81,
             "NameEnd": 85
           },
           "Column": {
             "Name": "f1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 86,
             "NameEnd": 88
           }
@@ -153,13 +153,13 @@
           "Database": null,
           "Table": {
             "Name": "cte2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 94,
             "NameEnd": 98
           },
           "Column": {
             "Name": "f2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 99,
             "NameEnd": 101
           }
@@ -168,13 +168,13 @@
           "Database": null,
           "Table": {
             "Name": "t3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 107,
             "NameEnd": 109
           },
           "Column": {
             "Name": "f3",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 110,
             "NameEnd": 112
           }
@@ -193,7 +193,7 @@
             "Database": null,
             "Table": {
               "Name": "t3",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 122,
               "NameEnd": 124
             }
@@ -210,7 +210,7 @@
               "Database": null,
               "Table": {
                 "Name": "cte1",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 125,
                 "NameEnd": 129
               }
@@ -225,7 +225,7 @@
               "Database": null,
               "Table": {
                 "Name": "cte2",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 130,
                 "NameEnd": 134
               }

--- a/parser/testdata/query/output/select_with_join_only.sql.golden.json
+++ b/parser/testdata/query/output/select_with_join_only.sql.golden.json
@@ -11,7 +11,7 @@
       "Items": [
         {
           "Name": "*",
-          "Unquoted": false,
+          "QuoteType": 0,
           "NamePos": 7,
           "NameEnd": 7
         }
@@ -28,9 +28,10 @@
           "Expr": {
             "Database": null,
             "Table": {
-              "LiteralPos": 15,
-              "LiteralEnd": 17,
-              "Literal": "t1"
+              "Name": "t1",
+              "QuoteType": 2,
+              "NamePos": 15,
+              "NameEnd": 17
             }
           },
           "HasFinal": false
@@ -42,9 +43,10 @@
           "Expr": {
             "Database": null,
             "Table": {
-              "LiteralPos": 25,
-              "LiteralEnd": 27,
-              "Literal": "t2"
+              "Name": "t2",
+              "QuoteType": 2,
+              "NamePos": 25,
+              "NameEnd": 27
             }
           },
           "HasFinal": false
@@ -62,7 +64,7 @@
             "Items": [
               {
                 "Name": "true",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 32,
                 "NameEnd": 36
               }

--- a/parser/testdata/query/output/select_with_left_join.sql.golden.json
+++ b/parser/testdata/query/output/select_with_left_join.sql.golden.json
@@ -10,7 +10,7 @@
           "CTEPos": 9,
           "Expr": {
             "Name": "t1",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 9,
             "NameEnd": 11
           },
@@ -34,7 +34,7 @@
                   "AliasPos": 46,
                   "Alias": {
                     "Name": "value",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 49,
                     "NameEnd": 54
                   }
@@ -62,7 +62,7 @@
           "CTEPos": 66,
           "Expr": {
             "Name": "t2",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 66,
             "NameEnd": 68
           },
@@ -86,7 +86,7 @@
                   "AliasPos": 90,
                   "Alias": {
                     "Name": "value",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 93,
                     "NameEnd": 98
                   }
@@ -120,7 +120,7 @@
       "Items": [
         {
           "Name": "*",
-          "Unquoted": false,
+          "QuoteType": 0,
           "NamePos": 112,
           "NameEnd": 112
         }
@@ -138,7 +138,7 @@
             "Database": null,
             "Table": {
               "Name": "t1",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 119,
               "NameEnd": 121
             }
@@ -153,7 +153,7 @@
             "Database": null,
             "Table": {
               "Name": "t2",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 141,
               "NameEnd": 143
             }
@@ -174,7 +174,7 @@
             "Items": [
               {
                 "Name": "true",
-                "Unquoted": false,
+                "QuoteType": 1,
                 "NamePos": 147,
                 "NameEnd": 151
               }

--- a/parser/testdata/query/output/select_with_literal_table_name.sql.golden.json
+++ b/parser/testdata/query/output/select_with_literal_table_name.sql.golden.json
@@ -11,7 +11,7 @@
       "Items": [
         {
           "Name": "table_name",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 7,
           "NameEnd": 17
         }
@@ -25,14 +25,16 @@
         "Alias": null,
         "Expr": {
           "Database": {
-            "LiteralPos": 24,
-            "LiteralEnd": 42,
-            "Literal": "information_schema"
+            "Name": "information_schema",
+            "QuoteType": 2,
+            "NamePos": 24,
+            "NameEnd": 42
           },
           "Table": {
-            "LiteralPos": 45,
-            "LiteralEnd": 51,
-            "Literal": "tables"
+            "Name": "tables",
+            "QuoteType": 2,
+            "NamePos": 45,
+            "NameEnd": 51
           }
         },
         "HasFinal": false

--- a/parser/testdata/query/output/select_with_string_expr.sql.golden.json
+++ b/parser/testdata/query/output/select_with_string_expr.sql.golden.json
@@ -9,9 +9,10 @@
         {
           "CTEPos": 6,
           "Expr": {
-            "LiteralPos": 6,
-            "LiteralEnd": 9,
-            "Literal": "abc"
+            "Name": "abc",
+            "QuoteType": 2,
+            "NamePos": 6,
+            "NameEnd": 9
           },
           "Alias": {
             "SelectPos": 15,
@@ -33,7 +34,7 @@
                   "AliasPos": 24,
                   "Alias": {
                     "Name": "a",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 27,
                     "NameEnd": 28
                   }
@@ -67,7 +68,7 @@
       "Items": [
         {
           "Name": "*",
-          "Unquoted": false,
+          "QuoteType": 0,
           "NamePos": 37,
           "NameEnd": 37
         }
@@ -82,9 +83,10 @@
         "Expr": {
           "Database": null,
           "Table": {
-            "LiteralPos": 45,
-            "LiteralEnd": 48,
-            "Literal": "abc"
+            "Name": "abc",
+            "QuoteType": 2,
+            "NamePos": 45,
+            "NameEnd": 48
           }
         },
         "HasFinal": false

--- a/parser/testdata/query/output/select_with_union_distinct.sql.golden.json
+++ b/parser/testdata/query/output/select_with_union_distinct.sql.golden.json
@@ -11,7 +11,7 @@
       "Items": [
         {
           "Name": "replica_name",
-          "Unquoted": false,
+          "QuoteType": 1,
           "NamePos": 7,
           "NameEnd": 19
         }
@@ -26,13 +26,13 @@
         "Expr": {
           "Database": {
             "Name": "system",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 25,
             "NameEnd": 31
           },
           "Table": {
             "Name": "ha_replicas",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 32,
             "NameEnd": 43
           }
@@ -64,7 +64,7 @@
         "Items": [
           {
             "Name": "replica_name",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 66,
             "NameEnd": 78
           }
@@ -79,13 +79,13 @@
           "Expr": {
             "Database": {
               "Name": "system",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 84,
               "NameEnd": 90
             },
             "Table": {
               "Name": "ha_unique_replicas",
-              "Unquoted": false,
+              "QuoteType": 1,
               "NamePos": 91,
               "NameEnd": 109
             }

--- a/parser/testdata/query/output/select_with_variable.sql.golden.json
+++ b/parser/testdata/query/output/select_with_variable.sql.golden.json
@@ -10,7 +10,7 @@
           "CTEPos": 5,
           "Expr": {
             "Name": "$abc",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 5,
             "NameEnd": 9
           },
@@ -34,7 +34,7 @@
                   "AliasPos": 23,
                   "Alias": {
                     "Name": "a",
-                    "Unquoted": false,
+                    "QuoteType": 1,
                     "NamePos": 26,
                     "NameEnd": 27
                   }
@@ -68,7 +68,7 @@
       "Items": [
         {
           "Name": "*",
-          "Unquoted": false,
+          "QuoteType": 0,
           "NamePos": 36,
           "NameEnd": 36
         }
@@ -84,7 +84,7 @@
           "Database": null,
           "Table": {
             "Name": "$abc",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 43,
             "NameEnd": 47
           }

--- a/parser/testdata/query/output/set_simple.sql.golden.json
+++ b/parser/testdata/query/output/set_simple.sql.golden.json
@@ -9,7 +9,7 @@
           "SettingsPos": 4,
           "Name": {
             "Name": "max_threads",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 4,
             "NameEnd": 15
           },
@@ -24,7 +24,7 @@
           "SettingsPos": 21,
           "Name": {
             "Name": "max_insert_threads",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 21,
             "NameEnd": 39
           },
@@ -39,7 +39,7 @@
           "SettingsPos": 45,
           "Name": {
             "Name": "max_block_size",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 45,
             "NameEnd": 59
           },
@@ -54,7 +54,7 @@
           "SettingsPos": 68,
           "Name": {
             "Name": "min_insert_block_size_rows",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 68,
             "NameEnd": 94
           },
@@ -69,7 +69,7 @@
           "SettingsPos": 103,
           "Name": {
             "Name": "min_insert_block_size_bytes",
-            "Unquoted": false,
+            "QuoteType": 1,
             "NamePos": 103,
             "NameEnd": 130
           },


### PR DESCRIPTION
This closes #53

ClickHouse should always regard the double quote string as an ident, which behaves differently with MySQL or other widely used databases.

also refer: https://clickhouse.com/docs/en/sql-reference/syntax#keywords