### PR TITLE
Parse select item alias even without `AS` keyword

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -735,7 +735,10 @@ func (p *Parser) parseSelectItem() (*SelectItem, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		alias = p.tryParseIdent()
 	}
+
 	return &SelectItem{
 		Expr:      expr,
 		Modifiers: modifiers,

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -78,6 +78,20 @@ func (p *Parser) tryConsumeKeyword(keyword string) *Token {
 	return nil
 }
 
+func (p *Parser) tryParseIdent() *Ident {
+	if p.lastTokenKind() != TokenKindIdent {
+		return nil
+	}
+	lastToken := p.last()
+	_ = p.lexer.consumeToken()
+	return &Ident{
+		NamePos:   lastToken.Pos,
+		NameEnd:   lastToken.End,
+		Name:      lastToken.String,
+		QuoteType: lastToken.QuoteType,
+	}
+}
+
 func (p *Parser) parseIdent() (*Ident, error) {
 	lastToken, err := p.consumeTokenKind(TokenKindIdent)
 	if err != nil {

--- a/parser/testdata/query/format/select_simple_field_alias.sql
+++ b/parser/testdata/query/format/select_simple_field_alias.sql
@@ -1,0 +1,5 @@
+-- Origin SQL:
+SELECT field0, field1 as x, field2 y from events;
+
+-- Format SQL:
+SELECT field0, field1 AS x, field2 AS y FROM events;

--- a/parser/testdata/query/output/select_simple_field_alias.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_field_alias.sql.golden.json
@@ -1,0 +1,88 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 48,
+    "With": null,
+    "Top": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "field0",
+          "QuoteType": 1,
+          "NamePos": 7,
+          "NameEnd": 13
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Name": "field1",
+          "QuoteType": 1,
+          "NamePos": 15,
+          "NameEnd": 21
+        },
+        "Modifiers": [],
+        "Alias": {
+          "Name": "x",
+          "QuoteType": 1,
+          "NamePos": 25,
+          "NameEnd": 26
+        }
+      },
+      {
+        "Expr": {
+          "Name": "field2",
+          "QuoteType": 1,
+          "NamePos": 28,
+          "NameEnd": 34
+        },
+        "Modifiers": [],
+        "Alias": {
+          "Name": "y",
+          "QuoteType": 1,
+          "NamePos": 35,
+          "NameEnd": 36
+        }
+      }
+    ],
+    "From": {
+      "FromPos": 37,
+      "Expr": {
+        "Table": {
+          "TablePos": 42,
+          "TableEnd": 48,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "events",
+              "QuoteType": 1,
+              "NamePos": 42,
+              "NameEnd": 48
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 48,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_simple_field_alias.sql
+++ b/parser/testdata/query/select_simple_field_alias.sql
@@ -1,0 +1,1 @@
+SELECT field0, field1 as x, field2 y from events;


### PR DESCRIPTION
ClickHouse allows to not use `AS` keyword when naming selected columns:

```
SELECT col1 AS one, col2 two
FROM tbl
```

Fix it.