### PR TITLE
Minor refactor the lexer to allow consuming multiple keywords at once

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -72,14 +72,27 @@ func (t *Token) ToString() string {
 	return t.String
 }
 
-type Lexer struct {
-	input     string
+type lexerState struct {
 	current   int
 	lastToken *Token
 }
 
+type Lexer struct {
+	lexerState
+
+	input string
+}
+
 func NewLexer(buf string) *Lexer {
 	return &Lexer{input: buf}
+}
+
+func (l *Lexer) saveState() lexerState {
+	return l.lexerState
+}
+
+func (l *Lexer) restoreState(state lexerState) {
+	l.lexerState = state
 }
 
 func (l *Lexer) skipN(n int) {
@@ -280,15 +293,13 @@ func (l *Lexer) skipComments() {
 }
 
 func (l *Lexer) peekToken() (*Token, error) {
-	saveToken := l.lastToken
-	saveCurrent := l.current
+	savedState := l.saveState()
 	if err := l.consumeToken(); err != nil {
 		return nil, err
 	}
 	token := l.lastToken
 
-	l.lastToken = saveToken
-	l.current = saveCurrent
+	l.restoreState(savedState)
 	return token, nil
 }
 

--- a/parser/parse_system.go
+++ b/parser/parse_system.go
@@ -33,7 +33,7 @@ func (p *Parser) parseSystemFlushExpr(pos Pos) (*SystemFlushExpr, error) {
 			StatementEnd: lastToken.End,
 			Logs:         true,
 		}, nil
-	case p.tryConsumeKeyword(KeywordDistributed) != nil:
+	case p.tryConsumeKeywords(KeywordDistributed):
 		distributed, err := p.parseTableIdentifier(p.Pos())
 		if err != nil {
 			return nil, err
@@ -62,7 +62,7 @@ func (p *Parser) parseSystemReloadExpr(pos Pos) (*SystemReloadExpr, error) {
 			StatementEnd: lastToken.End,
 			Type:         KeywordDictionaries,
 		}, nil
-	case p.tryConsumeKeyword(KeywordDictionary) != nil:
+	case p.tryConsumeKeywords(KeywordDictionary):
 		dictionary, err := p.parseTableIdentifier(p.Pos())
 		if err != nil {
 			return nil, err
@@ -73,7 +73,7 @@ func (p *Parser) parseSystemReloadExpr(pos Pos) (*SystemReloadExpr, error) {
 			Type:         KeywordDictionary,
 			Dictionary:   dictionary,
 		}, nil
-	case p.tryConsumeKeyword("EMBEDDED") != nil:
+	case p.tryConsumeKeywords("EMBEDDED"):
 		lastToken := p.last()
 		if err := p.expectKeyword(KeywordDictionaries); err != nil {
 			return nil, err
@@ -114,7 +114,7 @@ func (p *Parser) parseSystemCtrlExpr(pos Pos) (*SystemCtrlExpr, error) {
 
 	var typ string
 	switch {
-	case p.tryConsumeKeyword(KeywordDistributed) != nil:
+	case p.tryConsumeKeywords(KeywordDistributed):
 		switch {
 		case p.matchKeyword(KeywordSends):
 			typ = "DISTRIBUTED SENDS"
@@ -141,7 +141,7 @@ func (p *Parser) parseSystemCtrlExpr(pos Pos) (*SystemCtrlExpr, error) {
 			Type:         typ,
 			Cluster:      cluster,
 		}, nil
-	case p.tryConsumeKeyword(KeywordReplicated) != nil:
+	case p.tryConsumeKeywords(KeywordReplicated):
 		lastToken := p.last()
 		if err := p.expectKeyword(KeywordSends); err != nil {
 			return nil, err
@@ -209,7 +209,7 @@ func (p *Parser) parseDeduplicateClause(pos Pos) (*DeduplicateClause, error) {
 	if err := p.expectKeyword(KeywordDeduplicate); err != nil {
 		return nil, err
 	}
-	if p.tryConsumeKeyword(KeywordBy) == nil {
+	if !p.tryConsumeKeywords(KeywordBy) {
 		return &DeduplicateClause{
 			DeduplicatePos: pos,
 		}, nil
@@ -220,7 +220,7 @@ func (p *Parser) parseDeduplicateClause(pos Pos) (*DeduplicateClause, error) {
 		return nil, err
 	}
 	var except *ColumnExprList
-	if p.tryConsumeKeyword(KeywordExcept) != nil {
+	if p.tryConsumeKeywords(KeywordExcept) {
 		except, err = p.parseColumnExprList(p.Pos())
 		if err != nil {
 			return nil, err
@@ -245,14 +245,14 @@ func (p *Parser) parseOptimizeStmt(pos Pos) (*OptimizeStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	statmentEnd := table.End()
+	statementEnd := table.End()
 
 	onCluster, err := p.tryParseClusterClause(p.Pos())
 	if err != nil {
 		return nil, err
 	}
 	if onCluster != nil {
-		statmentEnd = onCluster.End()
+		statementEnd = onCluster.End()
 	}
 
 	partition, err := p.tryParsePartitionClause(p.Pos())
@@ -260,14 +260,14 @@ func (p *Parser) parseOptimizeStmt(pos Pos) (*OptimizeStmt, error) {
 		return nil, err
 	}
 	if partition != nil {
-		statmentEnd = partition.End()
+		statementEnd = partition.End()
 	}
 
 	hasFinal := false
 	lastPos := p.Pos()
-	if p.tryConsumeKeyword(KeywordFinal) != nil {
+	if p.tryConsumeKeywords(KeywordFinal) {
 		hasFinal = true
-		statmentEnd = lastPos
+		statementEnd = lastPos
 	}
 
 	deduplicate, err := p.tryParseDeduplicateClause(p.Pos())
@@ -275,12 +275,12 @@ func (p *Parser) parseOptimizeStmt(pos Pos) (*OptimizeStmt, error) {
 		return nil, err
 	}
 	if deduplicate != nil {
-		statmentEnd = deduplicate.End()
+		statementEnd = deduplicate.End()
 	}
 
 	return &OptimizeStmt{
 		OptimizePos:  pos,
-		StatementEnd: statmentEnd,
+		StatementEnd: statementEnd,
 		Table:        table,
 		OnCluster:    onCluster,
 		Partition:    partition,
@@ -383,7 +383,7 @@ func (p *Parser) parseRoleName(_ Pos) (*RoleName, error) {
 }
 
 func (p *Parser) tryParseRoleSettings(pos Pos) ([]*RoleSetting, error) {
-	if p.tryConsumeKeyword(KeywordSettings) == nil {
+	if !p.tryConsumeKeywords(KeywordSettings) {
 		return nil, nil
 	}
 	return p.parseRoleSettings(pos)
@@ -495,7 +495,7 @@ func (p *Parser) parseCreateRole(pos Pos) (*CreateRole, error) {
 	statementEnd := roleNames[len(roleNames)-1].End()
 
 	var accessStorageType *Ident
-	if p.tryConsumeKeyword(KeywordIn) != nil {
+	if p.tryConsumeKeywords(KeywordIn) {
 		accessStorageType, err = p.parseIdent()
 		if err != nil {
 			return nil, err
@@ -561,7 +561,7 @@ func (p *Parser) parserDropUserOrRole(pos Pos) (*DropUserOrRole, error) {
 	}
 
 	var from *Ident
-	if p.tryConsumeKeyword(KeywordFrom) != nil {
+	if p.tryConsumeKeywords(KeywordFrom) {
 		from, err = p.parseIdent()
 		if err != nil {
 			return nil, err
@@ -606,7 +606,7 @@ func (p *Parser) parsePrivilegeSelectOrInsert(pos Pos) (*PrivilegeClause, error)
 func (p *Parser) parsePrivilegeAlter(pos Pos) (*PrivilegeClause, error) {
 	keywords := []string{KeywordAlter}
 	switch {
-	case p.tryConsumeKeyword(KeywordIndex) != nil:
+	case p.tryConsumeKeywords(KeywordIndex):
 		keywords = append(keywords, KeywordIndex)
 	case p.matchKeyword(KeywordUpdate), p.matchKeyword(KeywordDelete),
 		p.matchKeyword(KeywordUser), p.matchKeyword(KeywordRole), p.matchKeyword(KeywordQuota):
@@ -621,35 +621,34 @@ func (p *Parser) parsePrivilegeAlter(pos Pos) (*PrivilegeClause, error) {
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
 		switch {
-		case p.tryConsumeKeyword(KeywordColumn) != nil:
+		case p.tryConsumeKeywords(KeywordColumn):
 			keywords = append(keywords, KeywordColumn)
-		case p.tryConsumeKeyword(KeywordIndex) != nil:
+		case p.tryConsumeKeywords(KeywordIndex):
 			keywords = append(keywords, KeywordIndex)
-		case p.tryConsumeKeyword(KeywordConstraint) != nil:
 			keywords = append(keywords, KeywordConstraint)
-		case p.tryConsumeKeyword(KeywordTtl) != nil:
+		case p.tryConsumeKeywords(KeywordTtl):
 			keywords = append(keywords, KeywordTtl)
 		default:
 			return nil, fmt.Errorf("expected COLUMN|INDEX")
 		}
-	case p.tryConsumeKeyword(KeywordOrder) != nil:
+	case p.tryConsumeKeywords(KeywordOrder):
 		if err := p.expectKeyword(KeywordBy); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordOrder, KeywordBy)
-	case p.tryConsumeKeyword(KeywordSample) != nil:
+	case p.tryConsumeKeywords(KeywordSample):
 		if err := p.expectKeyword(KeywordBy); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordSample, KeywordBy)
-	case p.tryConsumeKeyword(KeywordSettings) != nil:
+	case p.tryConsumeKeywords(KeywordSettings):
 		keywords = append(keywords, KeywordSettings)
-	case p.tryConsumeKeyword(KeywordView) != nil:
+	case p.tryConsumeKeywords(KeywordView):
 		keywords = append(keywords, KeywordView)
 		switch {
-		case p.tryConsumeKeyword(KeywordModify) != nil:
+		case p.tryConsumeKeywords(KeywordModify):
 			keywords = append(keywords, KeywordModify)
-		case p.tryConsumeKeyword(KeywordRefresh) != nil:
+		case p.tryConsumeKeywords(KeywordRefresh):
 			keywords = append(keywords, KeywordRefresh)
 		default:
 			return nil, fmt.Errorf("expected MODIFY|REFRESH")
@@ -680,12 +679,12 @@ func (p *Parser) parsePrivilegeCreate(pos Pos) (*PrivilegeClause, error) {
 		keyword := p.last().String
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
-	case p.tryConsumeKeyword(KeywordTemporary) != nil:
+	case p.tryConsumeKeywords(KeywordTemporary):
 		if err := p.expectKeyword(KeywordTable); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordTemporary, KeywordTable)
-	case p.tryConsumeKeyword(KeywordRows) != nil:
+	case p.tryConsumeKeywords(KeywordRows):
 		if err := p.expectKeyword(KeywordPolicy); err != nil {
 			return nil, err
 		}
@@ -742,10 +741,10 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		keyword := p.last().String
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
-	case p.tryConsumeKeyword(KeywordDrop) != nil:
+	case p.tryConsumeKeywords(KeywordDrop):
 		keywords = append(keywords, KeywordDrop)
 		switch {
-		case p.tryConsumeKeyword(KeywordCache) != nil:
+		case p.tryConsumeKeywords(KeywordCache):
 			keywords = append(keywords, KeywordCache)
 		case p.matchKeyword(KeywordMark), p.matchKeyword(KeywordDNS), p.matchKeyword(KeywordUncompressed):
 			keyword := p.last().String
@@ -758,7 +757,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		default:
 			return nil, fmt.Errorf("expected CACHE|MARK|DNS|UNCOMPRESSED")
 		}
-	case p.tryConsumeKeyword(KeywordReload) != nil:
+	case p.tryConsumeKeywords(KeywordReload):
 		keywords = append(keywords, KeywordReload)
 		switch {
 		case p.matchKeyword(KeywordDictionary), p.matchKeyword(KeywordFunction),
@@ -769,7 +768,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		default:
 			return nil, fmt.Errorf("expected DICTIONARY|FUNCTION|FUNCTIONS|CONFIG")
 		}
-	case p.tryConsumeKeyword(KeywordFlush) != nil:
+	case p.tryConsumeKeywords(KeywordFlush):
 		keywords = append(keywords, KeywordFlush)
 		switch {
 		case p.matchKeyword(KeywordLogs), p.matchKeyword(KeywordDistributed):
@@ -779,7 +778,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		default:
 			return nil, fmt.Errorf("expected LOGS|DISTRIBUTED")
 		}
-	case p.tryConsumeKeyword(KeywordTtl) != nil:
+	case p.tryConsumeKeywords(KeywordTtl):
 		keywords = append(keywords, KeywordTtl)
 		if err := p.expectKeyword(KeywordMerges); err != nil {
 			return nil, err
@@ -793,7 +792,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordReplica)
-	case p.tryConsumeKeyword(KeywordReplication) != nil:
+	case p.tryConsumeKeywords(KeywordReplication):
 		keywords = append(keywords, KeywordReplication)
 		if err := p.expectKeyword(KeywordQueues); err != nil {
 			return nil, err
@@ -821,13 +820,13 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 	switch {
 	case p.matchKeyword(KeywordSelect), p.matchKeyword(KeywordInsert):
 		return p.parsePrivilegeSelectOrInsert(pos)
-	case p.tryConsumeKeyword(KeywordAlter) != nil:
+	case p.tryConsumeKeywords(KeywordAlter):
 		return p.parsePrivilegeAlter(pos)
-	case p.tryConsumeKeyword(KeywordCreate) != nil:
+	case p.tryConsumeKeywords(KeywordCreate):
 		return p.parsePrivilegeCreate(pos)
-	case p.tryConsumeKeyword(KeywordDrop) != nil:
+	case p.tryConsumeKeywords(KeywordDrop):
 		return p.parsePrivilegeDrop(pos)
-	case p.tryConsumeKeyword(KeywordShow) != nil:
+	case p.tryConsumeKeywords(KeywordShow):
 		return p.parsePrivilegeShow(pos)
 	case p.matchKeyword(KeywordAll), p.matchTokenKind(KeywordNone):
 		_ = p.lexer.consumeToken()
@@ -835,7 +834,7 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 			PrivilegePos: pos,
 			Keywords:     []string{KeywordAll},
 		}, nil
-	case p.tryConsumeKeyword(KeywordKill) != nil:
+	case p.tryConsumeKeywords(KeywordKill):
 		if err := p.expectKeyword(KeywordQuery); err != nil {
 			return nil, err
 		}
@@ -843,9 +842,9 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 			PrivilegePos: pos,
 			Keywords:     []string{KeywordKill, KeywordQuery},
 		}, nil
-	case p.tryConsumeKeyword(KeywordSystem) != nil:
+	case p.tryConsumeKeywords(KeywordSystem):
 		return p.parsePrivilegeSystem(pos)
-	case p.tryConsumeKeyword(KeywordAdmin) != nil:
+	case p.tryConsumeKeywords(KeywordAdmin):
 		if err := p.expectKeyword(KeywordOption); err != nil {
 			return nil, err
 		}
@@ -860,7 +859,7 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 			PrivilegePos: pos,
 			Keywords:     []string{keyword},
 		}, nil
-	case p.tryConsumeKeyword(KeywordRole) != nil:
+	case p.tryConsumeKeywords(KeywordRole):
 		if err := p.expectKeyword(KeywordAdmin); err != nil {
 			return nil, err
 		}
@@ -1047,7 +1046,7 @@ func (p *Parser) parseRoleRenamePair(_ Pos) (*RoleRenamePair, error) {
 		RoleName:     roleName,
 		StatementEnd: roleName.End(),
 	}
-	if p.tryConsumeKeyword(KeywordRename) != nil {
+	if p.tryConsumeKeywords(KeywordRename) {
 		if err := p.expectKeyword(KeywordTo); err != nil {
 			return nil, err
 		}

--- a/parser/parse_system.go
+++ b/parser/parse_system.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (p *Parser) parseSetStmt(pos Pos) (*SetStmt, error) {
-	if err := p.consumeKeyword(KeywordSet); err != nil {
+	if err := p.expectKeyword(KeywordSet); err != nil {
 		return nil, err
 	}
 	settings, err := p.parseSettingsClause(p.Pos())
@@ -20,7 +20,7 @@ func (p *Parser) parseSetStmt(pos Pos) (*SetStmt, error) {
 }
 
 func (p *Parser) parseSystemFlushExpr(pos Pos) (*SystemFlushExpr, error) {
-	if err := p.consumeKeyword(KeywordFlush); err != nil {
+	if err := p.expectKeyword(KeywordFlush); err != nil {
 		return nil, err
 	}
 
@@ -49,7 +49,7 @@ func (p *Parser) parseSystemFlushExpr(pos Pos) (*SystemFlushExpr, error) {
 }
 
 func (p *Parser) parseSystemReloadExpr(pos Pos) (*SystemReloadExpr, error) {
-	if err := p.consumeKeyword(KeywordReload); err != nil {
+	if err := p.expectKeyword(KeywordReload); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (p *Parser) parseSystemReloadExpr(pos Pos) (*SystemReloadExpr, error) {
 		}, nil
 	case p.tryConsumeKeyword("EMBEDDED") != nil:
 		lastToken := p.last()
-		if err := p.consumeKeyword(KeywordDictionaries); err != nil {
+		if err := p.expectKeyword(KeywordDictionaries); err != nil {
 			return nil, err
 		}
 		return &SystemReloadExpr{
@@ -89,10 +89,10 @@ func (p *Parser) parseSystemReloadExpr(pos Pos) (*SystemReloadExpr, error) {
 }
 
 func (p *Parser) parseSystemSyncExpr(pos Pos) (*SystemSyncExpr, error) {
-	if err := p.consumeKeyword(KeywordSync); err != nil {
+	if err := p.expectKeyword(KeywordSync); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordReplica); err != nil {
+	if err := p.expectKeyword(KeywordReplica); err != nil {
 		return nil, err
 	}
 	cluster, err := p.parseTableIdentifier(p.Pos())
@@ -124,7 +124,7 @@ func (p *Parser) parseSystemCtrlExpr(pos Pos) (*SystemCtrlExpr, error) {
 			typ = "MERGES"
 		case p.matchKeyword(KeywordTtl):
 			typ = "TTL MERGES"
-			if err := p.consumeKeyword(KeywordMerges); err != nil {
+			if err := p.expectKeyword(KeywordMerges); err != nil {
 				return nil, err
 			}
 		default:
@@ -143,7 +143,7 @@ func (p *Parser) parseSystemCtrlExpr(pos Pos) (*SystemCtrlExpr, error) {
 		}, nil
 	case p.tryConsumeKeyword(KeywordReplicated) != nil:
 		lastToken := p.last()
-		if err := p.consumeKeyword(KeywordSends); err != nil {
+		if err := p.expectKeyword(KeywordSends); err != nil {
 			return nil, err
 		}
 		typ = "REPLICATED SENDS"
@@ -159,7 +159,7 @@ func (p *Parser) parseSystemCtrlExpr(pos Pos) (*SystemCtrlExpr, error) {
 }
 
 func (p *Parser) parseSystemDropExpr(pos Pos) (*SystemDropExpr, error) {
-	if err := p.consumeKeyword(KeywordDrop); err != nil {
+	if err := p.expectKeyword(KeywordDrop); err != nil {
 		return nil, err
 	}
 	switch {
@@ -171,7 +171,7 @@ func (p *Parser) parseSystemDropExpr(pos Pos) (*SystemDropExpr, error) {
 		prefixToken := p.last()
 		_ = p.lexer.consumeToken()
 		lastToken := p.last()
-		if err := p.consumeKeyword(KeywordCache); err != nil {
+		if err := p.expectKeyword(KeywordCache); err != nil {
 			return nil, err
 		}
 		return &SystemDropExpr{
@@ -181,11 +181,11 @@ func (p *Parser) parseSystemDropExpr(pos Pos) (*SystemDropExpr, error) {
 		}, nil
 	case p.matchKeyword(KeywordCompiled):
 		_ = p.lexer.consumeToken()
-		if err := p.consumeKeyword(KeywordExpression); err != nil {
+		if err := p.expectKeyword(KeywordExpression); err != nil {
 			return nil, err
 		}
 		lastToken := p.last()
-		if err := p.consumeKeyword(KeywordCache); err != nil {
+		if err := p.expectKeyword(KeywordCache); err != nil {
 			return nil, err
 		}
 		return &SystemDropExpr{
@@ -206,7 +206,7 @@ func (p *Parser) tryParseDeduplicateClause(pos Pos) (*DeduplicateClause, error) 
 }
 
 func (p *Parser) parseDeduplicateClause(pos Pos) (*DeduplicateClause, error) {
-	if err := p.consumeKeyword(KeywordDeduplicate); err != nil {
+	if err := p.expectKeyword(KeywordDeduplicate); err != nil {
 		return nil, err
 	}
 	if p.tryConsumeKeyword(KeywordBy) == nil {
@@ -234,10 +234,10 @@ func (p *Parser) parseDeduplicateClause(pos Pos) (*DeduplicateClause, error) {
 }
 
 func (p *Parser) parseOptimizeStmt(pos Pos) (*OptimizeStmt, error) {
-	if err := p.consumeKeyword(KeywordOptimize); err != nil {
+	if err := p.expectKeyword(KeywordOptimize); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordTable); err != nil {
+	if err := p.expectKeyword(KeywordTable); err != nil {
 		return nil, err
 	}
 
@@ -290,7 +290,7 @@ func (p *Parser) parseOptimizeStmt(pos Pos) (*OptimizeStmt, error) {
 }
 
 func (p *Parser) parseSystemStmt(pos Pos) (*SystemStmt, error) {
-	if err := p.consumeKeyword(KeywordSystem); err != nil {
+	if err := p.expectKeyword(KeywordSystem); err != nil {
 		return nil, err
 	}
 
@@ -320,10 +320,10 @@ func (p *Parser) parseSystemStmt(pos Pos) (*SystemStmt, error) {
 }
 
 func (p *Parser) parseCheckStmt(pos Pos) (*CheckStmt, error) {
-	if err := p.consumeKeyword(KeywordCheck); err != nil {
+	if err := p.expectKeyword(KeywordCheck); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordTable); err != nil {
+	if err := p.expectKeyword(KeywordTable); err != nil {
 		return nil, err
 	}
 	table, err := p.parseTableIdentifier(p.Pos())
@@ -455,7 +455,7 @@ func (p *Parser) parseRoleSettings(_ Pos) ([]*RoleSetting, error) {
 }
 
 func (p *Parser) parseCreateRole(pos Pos) (*CreateRole, error) {
-	if err := p.consumeKeyword(KeywordRole); err != nil {
+	if err := p.expectKeyword(KeywordRole); err != nil {
 		return nil, err
 	}
 
@@ -464,16 +464,16 @@ func (p *Parser) parseCreateRole(pos Pos) (*CreateRole, error) {
 	switch {
 	case p.matchKeyword(KeywordIf):
 		_ = p.lexer.consumeToken()
-		if err := p.consumeKeyword(KeywordNot); err != nil {
+		if err := p.expectKeyword(KeywordNot); err != nil {
 			return nil, err
 		}
-		if err := p.consumeKeyword(KeywordExists); err != nil {
+		if err := p.expectKeyword(KeywordExists); err != nil {
 			return nil, err
 		}
 		ifNotExists = true
 	case p.matchKeyword(KeywordOr):
 		_ = p.lexer.consumeToken()
-		if err := p.consumeKeyword(KeywordReplace); err != nil {
+		if err := p.expectKeyword(KeywordReplace); err != nil {
 			return nil, err
 		}
 		orReplace = true
@@ -633,12 +633,12 @@ func (p *Parser) parsePrivilegeAlter(pos Pos) (*PrivilegeClause, error) {
 			return nil, fmt.Errorf("expected COLUMN|INDEX")
 		}
 	case p.tryConsumeKeyword(KeywordOrder) != nil:
-		if err := p.consumeKeyword(KeywordBy); err != nil {
+		if err := p.expectKeyword(KeywordBy); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordOrder, KeywordBy)
 	case p.tryConsumeKeyword(KeywordSample) != nil:
-		if err := p.consumeKeyword(KeywordBy); err != nil {
+		if err := p.expectKeyword(KeywordBy); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordSample, KeywordBy)
@@ -658,7 +658,7 @@ func (p *Parser) parsePrivilegeAlter(pos Pos) (*PrivilegeClause, error) {
 		keyword := p.last().String
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
-		if err := p.consumeKeyword(KeywordPartition); err != nil {
+		if err := p.expectKeyword(KeywordPartition); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordPartition)
@@ -681,12 +681,12 @@ func (p *Parser) parsePrivilegeCreate(pos Pos) (*PrivilegeClause, error) {
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
 	case p.tryConsumeKeyword(KeywordTemporary) != nil:
-		if err := p.consumeKeyword(KeywordTable); err != nil {
+		if err := p.expectKeyword(KeywordTable); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordTemporary, KeywordTable)
 	case p.tryConsumeKeyword(KeywordRows) != nil:
-		if err := p.consumeKeyword(KeywordPolicy); err != nil {
+		if err := p.expectKeyword(KeywordPolicy); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordRows, KeywordPolicy)
@@ -751,7 +751,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 			keyword := p.last().String
 			_ = p.lexer.consumeToken()
 			keywords = append(keywords, keyword)
-			if err := p.consumeKeyword(KeywordCache); err != nil {
+			if err := p.expectKeyword(KeywordCache); err != nil {
 				return nil, err
 			}
 			keywords = append(keywords, KeywordCache)
@@ -781,7 +781,7 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		}
 	case p.tryConsumeKeyword(KeywordTtl) != nil:
 		keywords = append(keywords, KeywordTtl)
-		if err := p.consumeKeyword(KeywordMerges); err != nil {
+		if err := p.expectKeyword(KeywordMerges); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordMerges)
@@ -789,13 +789,13 @@ func (p *Parser) parsePrivilegeSystem(pos Pos) (*PrivilegeClause, error) {
 		keyword := p.last().String
 		_ = p.lexer.consumeToken()
 		keywords = append(keywords, keyword)
-		if err := p.consumeKeyword(KeywordReplica); err != nil {
+		if err := p.expectKeyword(KeywordReplica); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordReplica)
 	case p.tryConsumeKeyword(KeywordReplication) != nil:
 		keywords = append(keywords, KeywordReplication)
-		if err := p.consumeKeyword(KeywordQueues); err != nil {
+		if err := p.expectKeyword(KeywordQueues); err != nil {
 			return nil, err
 		}
 		keywords = append(keywords, KeywordQueues)
@@ -836,7 +836,7 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 			Keywords:     []string{KeywordAll},
 		}, nil
 	case p.tryConsumeKeyword(KeywordKill) != nil:
-		if err := p.consumeKeyword(KeywordQuery); err != nil {
+		if err := p.expectKeyword(KeywordQuery); err != nil {
 			return nil, err
 		}
 		return &PrivilegeClause{
@@ -846,7 +846,7 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 	case p.tryConsumeKeyword(KeywordSystem) != nil:
 		return p.parsePrivilegeSystem(pos)
 	case p.tryConsumeKeyword(KeywordAdmin) != nil:
-		if err := p.consumeKeyword(KeywordOption); err != nil {
+		if err := p.expectKeyword(KeywordOption); err != nil {
 			return nil, err
 		}
 		return &PrivilegeClause{
@@ -861,7 +861,7 @@ func (p *Parser) parsePrivilegeClause(pos Pos) (*PrivilegeClause, error) {
 			Keywords:     []string{keyword},
 		}, nil
 	case p.tryConsumeKeyword(KeywordRole) != nil:
-		if err := p.consumeKeyword(KeywordAdmin); err != nil {
+		if err := p.expectKeyword(KeywordAdmin); err != nil {
 			return nil, err
 		}
 		return &PrivilegeClause{
@@ -902,14 +902,14 @@ func (p *Parser) parseGrantOptions(_ Pos) ([]string, error) {
 }
 
 func (p *Parser) parseGrantOption(_ Pos) (string, error) {
-	if err := p.consumeKeyword(KeywordWith); err != nil {
+	if err := p.expectKeyword(KeywordWith); err != nil {
 		return "", err
 	}
 	ident, err := p.parseIdent()
 	if err != nil {
 		return "", err
 	}
-	if err := p.consumeKeyword(KeywordOption); err != nil {
+	if err := p.expectKeyword(KeywordOption); err != nil {
 		return "", err
 	}
 	return ident.Name, nil
@@ -937,7 +937,7 @@ func (p *Parser) parseGrantSource(_ Pos) (*TableIdentifier, error) {
 }
 
 func (p *Parser) parseGrantPrivilegeStmt(pos Pos) (*GrantPrivilegeStmt, error) {
-	if err := p.consumeKeyword(KeywordGrant); err != nil {
+	if err := p.expectKeyword(KeywordGrant); err != nil {
 		return nil, err
 	}
 	onCluster, err := p.tryParseClusterClause(p.Pos())
@@ -959,7 +959,7 @@ func (p *Parser) parseGrantPrivilegeStmt(pos Pos) (*GrantPrivilegeStmt, error) {
 	}
 	statementEnd := privileges[len(privileges)-1].End()
 
-	if err := p.consumeKeyword(KeywordOn); err != nil {
+	if err := p.expectKeyword(KeywordOn); err != nil {
 		return nil, err
 	}
 	on, err := p.parseGrantSource(p.Pos())
@@ -967,7 +967,7 @@ func (p *Parser) parseGrantPrivilegeStmt(pos Pos) (*GrantPrivilegeStmt, error) {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordTo); err != nil {
+	if err := p.expectKeyword(KeywordTo); err != nil {
 		return nil, err
 	}
 	toRoles, err := p.parsePrivilegeRoles(p.Pos())
@@ -997,7 +997,7 @@ func (p *Parser) parseGrantPrivilegeStmt(pos Pos) (*GrantPrivilegeStmt, error) {
 }
 
 func (p *Parser) parseAlterRole(pos Pos) (*AlterRole, error) {
-	if err := p.consumeKeyword(KeywordRole); err != nil {
+	if err := p.expectKeyword(KeywordRole); err != nil {
 		return nil, err
 	}
 
@@ -1048,7 +1048,7 @@ func (p *Parser) parseRoleRenamePair(_ Pos) (*RoleRenamePair, error) {
 		StatementEnd: roleName.End(),
 	}
 	if p.tryConsumeKeyword(KeywordRename) != nil {
-		if err := p.consumeKeyword(KeywordTo); err != nil {
+		if err := p.expectKeyword(KeywordTo); err != nil {
 			return nil, err
 		}
 		newName, err := p.parseIdent()

--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -10,7 +10,7 @@ func (p *Parser) parseAlterTable(pos Pos) (*AlterTable, error) {
 		AlterPos:   pos,
 		AlterExprs: make([]AlterTableClause, 0),
 	}
-	if err := p.consumeKeyword(KeywordTable); err != nil {
+	if err := p.expectKeyword(KeywordTable); err != nil {
 		return nil, err
 	}
 
@@ -71,7 +71,7 @@ func (p *Parser) parseAlterTable(pos Pos) (*AlterTable, error) {
 }
 
 func (p *Parser) parseAlterTableAdd(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordAdd); err != nil {
+	if err := p.expectKeyword(KeywordAdd); err != nil {
 		return nil, err
 	}
 
@@ -88,7 +88,7 @@ func (p *Parser) parseAlterTableAdd(pos Pos) (AlterTableClause, error) {
 }
 
 func (p *Parser) parseAlterTableAddColumn(pos Pos) (*AlterTableAddColumn, error) {
-	if err := p.consumeKeyword(KeywordColumn); err != nil {
+	if err := p.expectKeyword(KeywordColumn); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func (p *Parser) parseAlterTableAddColumn(pos Pos) (*AlterTableAddColumn, error)
 
 func (p *Parser) parseAlterTableAddIndex(pos Pos) (*AlterTableAddIndex, error) {
 	indexPos := p.Pos()
-	if err := p.consumeKeyword(KeywordIndex); err != nil {
+	if err := p.expectKeyword(KeywordIndex); err != nil {
 		return nil, err
 	}
 
@@ -152,10 +152,10 @@ func (p *Parser) parseAlterTableAddIndex(pos Pos) (*AlterTableAddIndex, error) {
 }
 
 func (p *Parser) parseProjectionOrderBy(pos Pos) (*ProjectionOrderByClause, error) {
-	if err := p.consumeKeyword(KeywordOrder); err != nil {
+	if err := p.expectKeyword(KeywordOrder); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordBy); err != nil {
+	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
 	}
 	columns, err := p.parseColumnExprList(p.Pos())
@@ -169,14 +169,14 @@ func (p *Parser) parseProjectionOrderBy(pos Pos) (*ProjectionOrderByClause, erro
 }
 
 func (p *Parser) parseProjectionSelect(pos Pos) (*ProjectionSelectStmt, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 	with, err := p.tryParseWithClause(p.Pos())
 	if err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordSelect); err != nil {
+	if err := p.expectKeyword(KeywordSelect); err != nil {
 		return nil, err
 	}
 	columns, err := p.parseColumnExprList(p.Pos())
@@ -191,7 +191,7 @@ func (p *Parser) parseProjectionSelect(pos Pos) (*ProjectionSelectStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	rightParen, err := p.consumeTokenKind(TokenKindRParen)
+	rightParen, err := p.expectTokenKind(TokenKindRParen)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (p *Parser) parseTableProjection(pos Pos) (*TableProjection, error) {
 }
 
 func (p *Parser) parseAlterTableAddProjection(pos Pos) (*AlterTableAddProjection, error) {
-	if err := p.consumeKeyword(KeywordProjection); err != nil {
+	if err := p.expectKeyword(KeywordProjection); err != nil {
 		return nil, err
 	}
 
@@ -262,7 +262,7 @@ func (p *Parser) parseTableIndex(pos Pos) (*TableIndex, error) {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordType); err != nil {
+	if err := p.expectKeyword(KeywordType); err != nil {
 		return nil, err
 	}
 	columnType, err := p.parseColumnType(p.Pos())
@@ -270,7 +270,7 @@ func (p *Parser) parseTableIndex(pos Pos) (*TableIndex, error) {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordGranularity); err != nil {
+	if err := p.expectKeyword(KeywordGranularity); err != nil {
 		return nil, err
 	}
 	granularity, err := p.parseDecimal(p.Pos())
@@ -288,7 +288,7 @@ func (p *Parser) parseTableIndex(pos Pos) (*TableIndex, error) {
 }
 
 func (p *Parser) parseAlterTableDrop(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordDrop); err != nil {
+	if err := p.expectKeyword(KeywordDrop); err != nil {
 		return nil, err
 	}
 
@@ -305,7 +305,7 @@ func (p *Parser) parseAlterTableDrop(pos Pos) (AlterTableClause, error) {
 // Syntax: ALTER TABLE DETACH partitionClause
 func (p *Parser) parseAlterTableDetachPartition(pos Pos) (AlterTableClause, error) {
 	partitionPos := p.Pos()
-	if err := p.consumeKeyword(KeywordPartition); err != nil {
+	if err := p.expectKeyword(KeywordPartition); err != nil {
 		return nil, err
 	}
 	partition := &PartitionClause{
@@ -337,7 +337,7 @@ func (p *Parser) tryParsePartitionClause(pos Pos) (*PartitionClause, error) {
 }
 
 func (p *Parser) parsePartitionClause(pos Pos) (*PartitionClause, error) {
-	if err := p.consumeKeyword(KeywordPartition); err != nil {
+	if err := p.expectKeyword(KeywordPartition); err != nil {
 		return nil, err
 	}
 
@@ -366,7 +366,7 @@ func (p *Parser) parsePartitionClause(pos Pos) (*PartitionClause, error) {
 func (p *Parser) parseAlterTableAttachPartition(pos Pos) (AlterTableClause, error) {
 	alterTable := &AlterTableAttachPartition{AttachPos: pos}
 
-	if err := p.consumeKeyword(KeywordAttach); err != nil {
+	if err := p.expectKeyword(KeywordAttach); err != nil {
 		return nil, err
 	}
 	partition, err := p.parsePartitionClause(p.Pos())
@@ -446,7 +446,7 @@ func (p *Parser) parseAlterTableDropPartition(pos Pos) (AlterTableClause, error)
 		hasDetached = true
 	}
 	partitionPos := p.Pos()
-	if err := p.consumeKeyword(KeywordPartition); err != nil {
+	if err := p.expectKeyword(KeywordPartition); err != nil {
 		return nil, err
 	}
 	partition := &PartitionClause{
@@ -472,7 +472,7 @@ func (p *Parser) parseAlterTableDropPartition(pos Pos) (AlterTableClause, error)
 }
 
 func (p *Parser) parseAlterTableFreezePartition(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordFreeze); err != nil {
+	if err := p.expectKeyword(KeywordFreeze); err != nil {
 		return nil, err
 	}
 	alterTable := &AlterTableFreezePartition{
@@ -492,11 +492,11 @@ func (p *Parser) parseAlterTableFreezePartition(pos Pos) (AlterTableClause, erro
 }
 
 func (p *Parser) parseAlterTableRemoveTTL(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordRemove); err != nil {
+	if err := p.expectKeyword(KeywordRemove); err != nil {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordTtl); err != nil {
+	if err := p.expectKeyword(KeywordTtl); err != nil {
 		return nil, err
 	}
 
@@ -507,7 +507,7 @@ func (p *Parser) parseAlterTableRemoveTTL(pos Pos) (AlterTableClause, error) {
 }
 
 func (p *Parser) parseAlterTableClear(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordClear); err != nil {
+	if err := p.expectKeyword(KeywordClear); err != nil {
 		return nil, err
 	}
 	return p.parseAlterTableClearClause(pos)
@@ -579,11 +579,11 @@ func (p *Parser) parseAlterTableClearClause(pos Pos) (AlterTableClause, error) {
 
 // Syntax: ALTER TABLE RENAME COLUMN (IF EXISTS)? nestedIdentifier TO nestedIdentifier
 func (p *Parser) parseAlterTableRenameColumn(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordRename); err != nil {
+	if err := p.expectKeyword(KeywordRename); err != nil {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordColumn); err != nil {
+	if err := p.expectKeyword(KeywordColumn); err != nil {
 		return nil, err
 	}
 
@@ -597,7 +597,7 @@ func (p *Parser) parseAlterTableRenameColumn(pos Pos) (AlterTableClause, error) 
 		return nil, err
 	}
 
-	if err = p.consumeKeyword(KeywordTo); err != nil {
+	if err = p.expectKeyword(KeywordTo); err != nil {
 		return nil, err
 	}
 
@@ -615,7 +615,7 @@ func (p *Parser) parseAlterTableRenameColumn(pos Pos) (AlterTableClause, error) 
 }
 
 func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordModify); err != nil {
+	if err := p.expectKeyword(KeywordModify); err != nil {
 		return nil, err
 	}
 
@@ -642,7 +642,7 @@ func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
 
 // syntax: MODIFY COLUMN (IF EXISTS)? tableColumnDfnt
 func (p *Parser) parseAlterTableModifyColumn(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordColumn); err != nil {
+	if err := p.expectKeyword(KeywordColumn); err != nil {
 		return nil, err
 	}
 
@@ -679,7 +679,7 @@ func (p *Parser) tryParseRemovePropertyTypeExpr(pos Pos) (*RemovePropertyType, e
 		return nil, nil
 	}
 
-	if err := p.consumeKeyword(KeywordRemove); err != nil {
+	if err := p.expectKeyword(KeywordRemove); err != nil {
 		return nil, err
 	}
 
@@ -695,7 +695,7 @@ func (p *Parser) tryParseRemovePropertyTypeExpr(pos Pos) (*RemovePropertyType, e
 }
 
 func (p *Parser) parseAlterTableReplacePartition(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordReplace); err != nil {
+	if err := p.expectKeyword(KeywordReplace); err != nil {
 		return nil, err
 	}
 
@@ -704,7 +704,7 @@ func (p *Parser) parseAlterTableReplacePartition(pos Pos) (AlterTableClause, err
 		return nil, err
 	}
 
-	if err = p.consumeKeyword(KeywordFrom); err != nil {
+	if err = p.expectKeyword(KeywordFrom); err != nil {
 		return nil, err
 	}
 
@@ -721,7 +721,7 @@ func (p *Parser) parseAlterTableReplacePartition(pos Pos) (AlterTableClause, err
 }
 
 func (p *Parser) parseAlterTableMaterialize(pos Pos) (AlterTableClause, error) {
-	if err := p.consumeKeyword(KeywordMaterialize); err != nil {
+	if err := p.expectKeyword(KeywordMaterialize); err != nil {
 		return nil, err
 	}
 	var kind string

--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -344,13 +344,13 @@ func (p *Parser) parsePartitionClause(pos Pos) (*PartitionClause, error) {
 	partition := &PartitionClause{
 		PartitionPos: pos,
 	}
-	if p.tryConsumeKeyword(KeywordId) != nil {
+	if p.tryConsumeKeywords(KeywordId) {
 		id, err := p.parseString(p.Pos())
 		if err != nil {
 			return nil, err
 		}
 		partition.ID = id
-	} else if p.tryConsumeKeyword(KeywordAll) != nil {
+	} else if p.tryConsumeKeywords(KeywordAll) {
 		partition.All = true
 	} else {
 		expr, err := p.parseExpr(p.Pos())
@@ -375,7 +375,7 @@ func (p *Parser) parseAlterTableAttachPartition(pos Pos) (AlterTableClause, erro
 	}
 	alterTable.Partition = partition
 	// FROM [db.]table?
-	if p.tryConsumeKeyword(KeywordFrom) != nil {
+	if p.tryConsumeKeywords(KeywordFrom) {
 		tableIdentifier, err := p.parseTableIdentifier(p.Pos())
 		if err != nil {
 			return nil, err
@@ -431,7 +431,7 @@ func (p *Parser) parseAlterTableDropClause(pos Pos) (AlterTableClause, error) {
 }
 
 func (p *Parser) tryParseAfterClause() (*NestedIdentifier, error) {
-	if p.tryConsumeKeyword(KeywordAfter) == nil {
+	if !p.tryConsumeKeywords(KeywordAfter) {
 		return nil, nil // nolint
 	}
 
@@ -540,7 +540,7 @@ func (p *Parser) parseAlterTableClearClause(pos Pos) (AlterTableClause, error) {
 	statementEnd := name.End()
 
 	var partition *PartitionClause
-	if p.tryConsumeKeyword(KeywordIn) != nil {
+	if p.tryConsumeKeywords(KeywordIn) {
 		partition, err = p.tryParsePartitionClause(p.Pos())
 		if err != nil {
 			return nil, err
@@ -745,7 +745,7 @@ func (p *Parser) parseAlterTableMaterialize(pos Pos) (AlterTableClause, error) {
 	}
 	statementEnd := name.End()
 	var partition *PartitionClause
-	if p.tryConsumeKeyword(KeywordIn) != nil {
+	if p.tryConsumeKeywords(KeywordIn) {
 		partition, err = p.tryParsePartitionClause(p.Pos())
 		if err != nil {
 			return nil, err

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -103,7 +103,7 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 			if err != nil {
 				return nil, err
 			}
-			if _, err = p.consumeTokenKind(TokenKindLParen); err != nil {
+			if _, err = p.expectTokenKind(TokenKindLParen); err != nil {
 				return nil, err
 			}
 			// it's a tuple type definition after "::" operator
@@ -131,7 +131,7 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		return p.parseBetweenClause(expr)
 	case p.matchKeyword(KeywordGlobal):
 		_ = p.lexer.consumeToken()
-		if p.consumeKeyword(KeywordIn) != nil {
+		if p.expectKeyword(KeywordIn) != nil {
 			return nil, fmt.Errorf("expected IN after GLOBAL, got %s", p.lastTokenKind())
 		}
 		rightExpr, err := p.parseSubExpr(p.Pos(), precedence)
@@ -198,7 +198,7 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 	case p.matchKeyword(KeywordIs):
 		_ = p.lexer.consumeToken()
 		isNotNull := p.tryConsumeKeyword(KeywordNot) != nil
-		if err := p.consumeKeyword(KeywordNull); err != nil {
+		if err := p.expectKeyword(KeywordNull); err != nil {
 			return nil, err
 		}
 		if isNotNull {
@@ -240,14 +240,14 @@ func (p *Parser) parseSubExpr(pos Pos, precedence int) (Expr, error) {
 }
 
 func (p *Parser) parseTernaryExpr(condition Expr) (*TernaryOperation, error) {
-	if _, err := p.consumeTokenKind(TokenKindQuestionMark); err != nil {
+	if _, err := p.expectTokenKind(TokenKindQuestionMark); err != nil {
 		return nil, err
 	}
 	trueExpr, err := p.parseExpr(p.Pos())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := p.consumeTokenKind(TokenKindColon); err != nil {
+	if _, err := p.expectTokenKind(TokenKindColon); err != nil {
 		return nil, err
 	}
 	falseExpr, err := p.parseExpr(p.Pos())
@@ -262,10 +262,10 @@ func (p *Parser) parseTernaryExpr(condition Expr) (*TernaryOperation, error) {
 }
 
 func (p *Parser) parseColumnExtractExpr(pos Pos) (*ExtractExpr, error) {
-	if err := p.consumeKeyword(KeywordExtract); err != nil {
+	if err := p.expectKeyword(KeywordExtract); err != nil {
 		return nil, err
 	}
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -279,7 +279,7 @@ func (p *Parser) parseColumnExtractExpr(pos Pos) (*ExtractExpr, error) {
 	}
 
 	fromPos := p.Pos()
-	if err := p.consumeKeyword(KeywordFrom); err != nil {
+	if err := p.expectKeyword(KeywordFrom); err != nil {
 		return nil, err
 	}
 
@@ -287,7 +287,7 @@ func (p *Parser) parseColumnExtractExpr(pos Pos) (*ExtractExpr, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &ExtractExpr{
@@ -393,11 +393,11 @@ func (p *Parser) parseColumnExpr(pos Pos) (Expr, error) { //nolint:funlen
 }
 
 func (p *Parser) parseColumnCastExpr(pos Pos) (Expr, error) {
-	if err := p.consumeKeyword(KeywordCast); err != nil {
+	if err := p.expectKeyword(KeywordCast); err != nil {
 		return nil, err
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -428,7 +428,7 @@ func (p *Parser) parseColumnCastExpr(pos Pos) (Expr, error) {
 		return nil, err
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 
@@ -503,7 +503,7 @@ func (p *Parser) parseSelectItems() ([]*SelectItem, error) {
 
 // Syntax: INTERVAL expr interval
 func (p *Parser) parseColumnExprInterval(pos Pos) (Expr, error) {
-	if err := p.consumeKeyword(KeywordInterval); err != nil {
+	if err := p.expectKeyword(KeywordInterval); err != nil {
 		return nil, err
 	}
 
@@ -546,7 +546,7 @@ func (p *Parser) parseFunctionExpr(_ Pos) (*FunctionExpr, error) {
 }
 
 func (p *Parser) parseColumnArgList(pos Pos) (*ColumnArgList, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 	distinct := false
@@ -565,7 +565,7 @@ func (p *Parser) parseColumnArgList(pos Pos) (*ColumnArgList, error) {
 		}
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &ColumnArgList{
@@ -577,7 +577,7 @@ func (p *Parser) parseColumnArgList(pos Pos) (*ColumnArgList, error) {
 }
 
 func (p *Parser) parseFunctionParams(pos Pos) (*ParamExprList, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 	params, err := p.parseColumnExprListWithLParen(p.Pos())
@@ -585,7 +585,7 @@ func (p *Parser) parseFunctionParams(pos Pos) (*ParamExprList, error) {
 		return nil, err
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	paramExprList := &ParamExprList{
@@ -608,7 +608,7 @@ func (p *Parser) parseFunctionParams(pos Pos) (*ParamExprList, error) {
 }
 
 func (p *Parser) parseMapLiteral(pos Pos) (*MapLiteral, error) {
-	if _, err := p.consumeTokenKind(TokenKindLBrace); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLBrace); err != nil {
 		return nil, err
 	}
 
@@ -618,7 +618,7 @@ func (p *Parser) parseMapLiteral(pos Pos) (*MapLiteral, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, err := p.consumeTokenKind(TokenKindColon); err != nil {
+		if _, err := p.expectTokenKind(TokenKindColon); err != nil {
 			return nil, err
 		}
 		value, err := p.parseExpr(p.Pos())
@@ -634,7 +634,7 @@ func (p *Parser) parseMapLiteral(pos Pos) (*MapLiteral, error) {
 		}
 	}
 	rightBracePos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRBrace); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRBrace); err != nil {
 		return nil, err
 	}
 	return &MapLiteral{
@@ -645,7 +645,7 @@ func (p *Parser) parseMapLiteral(pos Pos) (*MapLiteral, error) {
 }
 
 func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
-	if _, err := p.consumeTokenKind(TokenKindLBrace); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLBrace); err != nil {
 		return nil, err
 	}
 
@@ -653,7 +653,7 @@ func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := p.consumeTokenKind(TokenKindColon); err != nil {
+	if _, err := p.expectTokenKind(TokenKindColon); err != nil {
 		return nil, err
 	}
 	columnType, err := p.parseColumnType(p.Pos())
@@ -661,7 +661,7 @@ func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
 		return nil, err
 	}
 	rightBracePos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRBrace); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRBrace); err != nil {
 		return nil, err
 	}
 	return &QueryParam{
@@ -673,7 +673,7 @@ func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
 }
 
 func (p *Parser) parseArrayParams(pos Pos) (*ArrayParamList, error) {
-	if _, err := p.consumeTokenKind(TokenKindLBracket); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLBracket); err != nil {
 		return nil, err
 	}
 	params, err := p.parseColumnExprListWithSquareBracket(p.Pos())
@@ -681,7 +681,7 @@ func (p *Parser) parseArrayParams(pos Pos) (*ArrayParamList, error) {
 		return nil, err
 	}
 	rightBracketPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRBracket); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRBracket); err != nil {
 		return nil, err
 	}
 	return &ArrayParamList{
@@ -749,7 +749,7 @@ func (p *Parser) parseSelectItem() (*SelectItem, error) {
 func (p *Parser) parseColumnCaseExpr(pos Pos) (*CaseExpr, error) {
 	// CASE expr
 	caseExpr := &CaseExpr{CasePos: pos}
-	if err := p.consumeKeyword(KeywordCase); err != nil {
+	if err := p.expectKeyword(KeywordCase); err != nil {
 		return nil, err
 	}
 
@@ -773,7 +773,7 @@ func (p *Parser) parseColumnCaseExpr(pos Pos) (*CaseExpr, error) {
 		}
 
 		thenPos := p.Pos()
-		if err := p.consumeKeyword(KeywordThen); err != nil {
+		if err := p.expectKeyword(KeywordThen); err != nil {
 			return nil, err
 		}
 		thenCondition, err := p.parseExpr(p.Pos())
@@ -800,7 +800,7 @@ func (p *Parser) parseColumnCaseExpr(pos Pos) (*CaseExpr, error) {
 		caseExpr.Else = elseExpr
 	}
 
-	if err := p.consumeKeyword(KeywordEnd); err != nil {
+	if err := p.expectKeyword(KeywordEnd); err != nil {
 		return nil, err
 	}
 
@@ -863,7 +863,7 @@ func (p *Parser) parseComplexType(name *Ident, pos Pos) (*ComplexType, error) {
 		}
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &ComplexType{
@@ -896,7 +896,7 @@ func (p *Parser) parseEnumType(name *Ident, pos Pos) (*EnumType, error) {
 	if len(enumType.Values) > 0 {
 		enumType.ListEnd = enumType.Values[len(enumType.Values)-1].Value.NumEnd
 	}
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return enumType, nil
@@ -918,7 +918,7 @@ func (p *Parser) parseColumnTypeWithParams(name *Ident, pos Pos) (*TypeWithParam
 	}
 
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &TypeWithParams{
@@ -991,7 +991,7 @@ func (p *Parser) parseJSONType(name *Ident, pos Pos) (*JSONType, error) {
 	}
 
 	rparenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &JSONType{
@@ -1010,7 +1010,7 @@ func (p *Parser) parseNestedType(name *Ident, pos Pos) (*NestedType, error) {
 		return nil, err
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &NestedType{
@@ -1026,7 +1026,7 @@ func (p *Parser) tryParseCompressionCodecs(pos Pos) (*CompressionCodec, error) {
 		return nil, nil // nolint
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -1048,7 +1048,7 @@ func (p *Parser) tryParseCompressionCodecs(pos Pos) (*CompressionCodec, error) {
 			return nil, err
 		}
 		// consume comma
-		if _, err := p.consumeTokenKind(TokenKindComma); err != nil {
+		if _, err := p.expectTokenKind(TokenKindComma); err != nil {
 			return nil, err
 		}
 		name, err = p.parseIdent()
@@ -1068,7 +1068,7 @@ func (p *Parser) tryParseCompressionCodecs(pos Pos) (*CompressionCodec, error) {
 	}
 
 	rightParenPos := p.last().End
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 
@@ -1088,7 +1088,7 @@ func (p *Parser) parseEnumValueExpr(pos Pos) (*EnumValue, error) {
 		return nil, err
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindSingleEQ); err != nil {
+	if _, err := p.expectTokenKind(TokenKindSingleEQ); err != nil {
 		return nil, err
 	}
 
@@ -1103,7 +1103,7 @@ func (p *Parser) parseEnumValueExpr(pos Pos) (*EnumValue, error) {
 }
 
 func (p *Parser) parseColumnStar(pos Pos) (*Ident, error) {
-	if _, err := p.consumeTokenKind("*"); err != nil {
+	if _, err := p.expectTokenKind("*"); err != nil {
 		return nil, err
 	}
 	return &Ident{
@@ -1123,7 +1123,7 @@ func (p *Parser) tryParseCompressionLevel(pos Pos) (*NumberLiteral, error) {
 		return nil, err
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return num, nil

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -69,6 +69,18 @@ func (p *Parser) consumeKeyword(keyword string) error {
 	return nil
 }
 
+func (p *Parser) parseKeywords(keywords ...string) bool {
+	savedState := p.lexer.saveState()
+	for _, keyword := range keywords {
+		if !p.matchKeyword(keyword) {
+			p.lexer.restoreState(savedState)
+			return false
+		}
+		_ = p.lexer.consumeToken()
+	}
+	return true
+}
+
 func (p *Parser) tryConsumeKeyword(keyword string) *Token {
 	if p.matchKeyword(keyword) {
 		lastToken := p.last()

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -81,15 +81,6 @@ func (p *Parser) tryConsumeKeywords(keywords ...string) bool {
 	return true
 }
 
-func (p *Parser) tryConsumeKeyword(keyword string) *Token {
-	if p.matchKeyword(keyword) {
-		lastToken := p.last()
-		_ = p.lexer.consumeToken()
-		return lastToken
-	}
-	return nil
-}
-
 func (p *Parser) tryParseIdent() *Ident {
 	if p.lastTokenKind() != TokenKindIdent {
 		return nil
@@ -164,14 +155,14 @@ func (p *Parser) tryParseUUID() (*UUID, error) {
 }
 
 func (p *Parser) tryParseComment() (*StringLiteral, error) {
-	if p.tryConsumeKeyword(KeywordComment) == nil {
+	if !p.tryConsumeKeywords(KeywordComment) {
 		return nil, nil
 	}
 	return p.parseString(p.Pos())
 }
 
 func (p *Parser) tryParseIfExists() (bool, error) {
-	if p.tryConsumeKeyword(KeywordIf) == nil {
+	if !p.tryConsumeKeywords(KeywordIf) {
 		return false, nil
 	}
 
@@ -182,7 +173,7 @@ func (p *Parser) tryParseIfExists() (bool, error) {
 }
 
 func (p *Parser) tryParseIfNotExists() (bool, error) {
-	if p.tryConsumeKeyword(KeywordIf) == nil {
+	if !p.tryConsumeKeywords(KeywordIf) {
 		return false, nil
 	}
 
@@ -197,14 +188,14 @@ func (p *Parser) tryParseIfNotExists() (bool, error) {
 }
 
 func (p *Parser) tryParseNull(pos Pos) *NullLiteral {
-	if p.tryConsumeKeyword(KeywordNull) == nil {
+	if !p.tryConsumeKeywords(KeywordNull) {
 		return nil
 	}
 	return &NullLiteral{NullPos: pos}
 }
 
 func (p *Parser) tryParseNotNull(pos Pos) (*NotNullLiteral, error) {
-	if p.tryConsumeKeyword(KeywordNot) == nil {
+	if !p.tryConsumeKeywords(KeywordNot) {
 		return nil, nil // nolint
 	}
 	notNull := &NotNullLiteral{NotPos: pos}

--- a/parser/parser_drop.go
+++ b/parser/parser_drop.go
@@ -1,7 +1,7 @@
 package parser
 
 func (p *Parser) parseDropDatabase(pos Pos) (*DropDatabase, error) {
-	if err := p.consumeKeyword(KeywordDatabase); err != nil {
+	if err := p.expectKeyword(KeywordDatabase); err != nil {
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (p *Parser) parseDropStmt(pos Pos) (*DropStmt, error) {
 		dropTarget = KeywordView
 	default:
 		isTemporary = p.tryConsumeKeyword(KeywordTemporary) != nil
-		if err := p.consumeKeyword(KeywordTable); err != nil {
+		if err := p.expectKeyword(KeywordTable); err != nil {
 			return nil, err
 		}
 	}
@@ -86,7 +86,7 @@ func (p *Parser) tryParseModifier() (string, error) {
 	case p.tryConsumeKeyword(KeywordSync) != nil:
 		return "SYNC", nil
 	case p.tryConsumeKeyword(KeywordNo) != nil:
-		if err := p.consumeKeyword(KeywordDelay); err != nil {
+		if err := p.expectKeyword(KeywordDelay); err != nil {
 			return "", err
 		}
 		return "NO DELAY", nil

--- a/parser/parser_drop.go
+++ b/parser/parser_drop.go
@@ -38,12 +38,12 @@ func (p *Parser) parseDropStmt(pos Pos) (*DropStmt, error) {
 	var isTemporary bool
 	dropTarget := KeywordTable
 	switch {
-	case p.tryConsumeKeyword(KeywordDictionary) != nil:
+	case p.tryConsumeKeywords(KeywordDictionary):
 		dropTarget = KeywordDictionary
-	case p.tryConsumeKeyword(KeywordView) != nil:
+	case p.tryConsumeKeywords(KeywordView):
 		dropTarget = KeywordView
 	default:
-		isTemporary = p.tryConsumeKeyword(KeywordTemporary) != nil
+		isTemporary = p.tryConsumeKeywords(KeywordTemporary)
 		if err := p.expectKeyword(KeywordTable); err != nil {
 			return nil, err
 		}
@@ -83,9 +83,9 @@ func (p *Parser) parseDropStmt(pos Pos) (*DropStmt, error) {
 
 func (p *Parser) tryParseModifier() (string, error) {
 	switch {
-	case p.tryConsumeKeyword(KeywordSync) != nil:
+	case p.tryConsumeKeywords(KeywordSync):
 		return "SYNC", nil
-	case p.tryConsumeKeyword(KeywordNo) != nil:
+	case p.tryConsumeKeywords(KeywordNo):
 		if err := p.expectKeyword(KeywordDelay); err != nil {
 			return "", err
 		}

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -13,7 +13,7 @@ func (p *Parser) tryParseWithClause(pos Pos) (*WithClause, error) {
 }
 
 func (p *Parser) parseWithClause(pos Pos) (*WithClause, error) {
-	if err := p.consumeKeyword(KeywordWith); err != nil {
+	if err := p.expectKeyword(KeywordWith); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +45,7 @@ func (p *Parser) tryParseTopClause(pos Pos) (*TopClause, error) {
 }
 
 func (p *Parser) parseTopClause(pos Pos) (*TopClause, error) {
-	if err := p.consumeKeyword(KeywordTop); err != nil {
+	if err := p.expectKeyword(KeywordTop); err != nil {
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func (p *Parser) parseTopClause(pos Pos) (*TopClause, error) {
 	withTies := false
 	if p.tryConsumeKeyword(KeywordWith) != nil {
 		topEnd = p.last().End
-		if err := p.consumeKeyword(KeywordTies); err != nil {
+		if err := p.expectKeyword(KeywordTies); err != nil {
 			return nil, err
 		}
 		withTies = true
@@ -79,7 +79,7 @@ func (p *Parser) tryParseFromClause(pos Pos) (*FromClause, error) {
 }
 
 func (p *Parser) parseFromClause(pos Pos) (*FromClause, error) {
-	if err := p.consumeKeyword(KeywordFrom); err != nil {
+	if err := p.expectKeyword(KeywordFrom); err != nil {
 		return nil, err
 	}
 
@@ -111,7 +111,7 @@ func (p *Parser) tryParseJoinConstraints(pos Pos) (Expr, error) {
 			return nil, err
 		}
 		if hasParen {
-			if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+			if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 				return nil, err
 			}
 		}
@@ -364,7 +364,7 @@ func (p *Parser) tryParsePrewhereClause(pos Pos) (*PrewhereClause, error) {
 	return p.parsePrewhereClause(pos)
 }
 func (p *Parser) parsePrewhereClause(pos Pos) (*PrewhereClause, error) {
-	if err := p.consumeKeyword(KeywordPrewhere); err != nil {
+	if err := p.expectKeyword(KeywordPrewhere); err != nil {
 		return nil, err
 	}
 
@@ -386,7 +386,7 @@ func (p *Parser) tryParseWhereClause(pos Pos) (*WhereClause, error) {
 }
 
 func (p *Parser) parseWhereClause(pos Pos) (*WhereClause, error) {
-	if err := p.consumeKeyword(KeywordWhere); err != nil {
+	if err := p.expectKeyword(KeywordWhere); err != nil {
 		return nil, err
 	}
 
@@ -409,10 +409,10 @@ func (p *Parser) tryParseGroupByClause(pos Pos) (*GroupByClause, error) {
 
 // syntax: groupByClause? (WITH (CUBE | ROLLUP))? (WITH TOTALS)?
 func (p *Parser) parseGroupByClause(pos Pos) (*GroupByClause, error) {
-	if err := p.consumeKeyword(KeywordGroup); err != nil {
+	if err := p.expectKeyword(KeywordGroup); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordBy); err != nil {
+	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
 	}
 
@@ -461,7 +461,7 @@ func (p *Parser) tryParseLimitClause(pos Pos) (*LimitClause, error) {
 }
 
 func (p *Parser) parseLimitClause(pos Pos) (*LimitClause, error) {
-	if err := p.consumeKeyword(KeywordLimit); err != nil {
+	if err := p.expectKeyword(KeywordLimit); err != nil {
 		return nil, err
 	}
 
@@ -496,7 +496,7 @@ func (p *Parser) tryParseLimitByClause(pos Pos) (Expr, error) {
 }
 
 func (p *Parser) parseBetweenClause(expr Expr) (*BetweenClause, error) {
-	if err := p.consumeKeyword(KeywordBetween); err != nil {
+	if err := p.expectKeyword(KeywordBetween); err != nil {
 		return nil, err
 	}
 
@@ -506,7 +506,7 @@ func (p *Parser) parseBetweenClause(expr Expr) (*BetweenClause, error) {
 	}
 
 	andPos := p.Pos()
-	if err := p.consumeKeyword(KeywordAnd); err != nil {
+	if err := p.expectKeyword(KeywordAnd); err != nil {
 		return nil, err
 	}
 
@@ -565,7 +565,7 @@ func (p *Parser) parseWindowFrameClause(pos Pos) (*WindowFrameClause, error) {
 		}
 
 		andPos := p.Pos()
-		if err := p.consumeKeyword(KeywordAnd); err != nil {
+		if err := p.expectKeyword(KeywordAnd); err != nil {
 			return nil, err
 		}
 
@@ -582,7 +582,7 @@ func (p *Parser) parseWindowFrameClause(pos Pos) (*WindowFrameClause, error) {
 		currentPos := p.Pos()
 		_ = p.lexer.consumeToken()
 		rowEnd := p.last().End
-		if err := p.consumeKeyword(KeywordRow); err != nil {
+		if err := p.expectKeyword(KeywordRow); err != nil {
 			return nil, err
 		}
 		expr = &WindowFrameCurrentRow{
@@ -644,7 +644,7 @@ func (p *Parser) tryParseWindowClause(pos Pos) (*WindowClause, error) {
 }
 
 func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 	partitionBy, err := p.tryParsePartitionByClause(pos)
@@ -660,7 +660,7 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 		return nil, err
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &WindowExpr{
@@ -673,7 +673,7 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 }
 
 func (p *Parser) parseWindowClause(pos Pos) (*WindowClause, error) {
-	if err := p.consumeKeyword(KeywordWindow); err != nil {
+	if err := p.expectKeyword(KeywordWindow); err != nil {
 		return nil, err
 	}
 
@@ -682,7 +682,7 @@ func (p *Parser) parseWindowClause(pos Pos) (*WindowClause, error) {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordAs); err != nil {
+	if err := p.expectKeyword(KeywordAs); err != nil {
 		return nil, err
 	}
 
@@ -713,11 +713,11 @@ func (p *Parser) parseArrayJoinClause(_ Pos) (*ArrayJoinClause, error) {
 		_ = p.lexer.consumeToken()
 	}
 	arrayPos := p.Pos()
-	if err := p.consumeKeyword(KeywordArray); err != nil {
+	if err := p.expectKeyword(KeywordArray); err != nil {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordJoin); err != nil {
+	if err := p.expectKeyword(KeywordJoin); err != nil {
 		return nil, err
 	}
 
@@ -741,7 +741,7 @@ func (p *Parser) tryParseHavingClause(pos Pos) (*HavingClause, error) {
 }
 
 func (p *Parser) parseHavingClause(pos Pos) (*HavingClause, error) {
-	if err := p.consumeKeyword(KeywordHaving); err != nil {
+	if err := p.expectKeyword(KeywordHaving); err != nil {
 		return nil, err
 	}
 
@@ -765,7 +765,7 @@ func (p *Parser) parseSubQuery(_ Pos) (*SubQuery, error) {
 		return nil, err
 	}
 	if hasParen {
-		if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+		if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 			return nil, err
 		}
 	}
@@ -812,7 +812,7 @@ func (p *Parser) parseSelectQuery(_ Pos) (*SelectQuery, error) {
 		selectStmt.Except = exceptExpr
 	}
 	if hasParen {
-		if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+		if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 			return nil, err
 		}
 	}
@@ -824,7 +824,7 @@ func (p *Parser) parseSelectStmt(pos Pos) (*SelectQuery, error) { // nolint: fun
 	if err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordSelect); err != nil {
+	if err := p.expectKeyword(KeywordSelect); err != nil {
 		return nil, err
 	}
 	// DISTINCT?
@@ -890,7 +890,7 @@ func (p *Parser) parseSelectStmt(pos Pos) (*SelectQuery, error) { // nolint: fun
 	withTotal := false
 	lastPos := p.Pos()
 	if p.tryConsumeKeyword(KeywordWith) != nil {
-		if err := p.consumeKeyword(KeywordTotals); err != nil {
+		if err := p.expectKeyword(KeywordTotals); err != nil {
 			return nil, err
 		}
 		withTotal = true
@@ -977,7 +977,7 @@ func (p *Parser) parseCTEStmt(pos Pos) (*CTEStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordAs); err != nil {
+	if err := p.expectKeyword(KeywordAs); err != nil {
 		return nil, err
 	}
 	if p.matchTokenKind(TokenKindLParen) {
@@ -1007,7 +1007,7 @@ func (p *Parser) tryParseColumnAliases() ([]*Ident, error) {
 	if !p.matchTokenKind(TokenKindLParen) {
 		return nil, nil
 	}
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -1021,11 +1021,11 @@ func (p *Parser) tryParseColumnAliases() ([]*Ident, error) {
 		if p.matchTokenKind(TokenKindRParen) {
 			break
 		}
-		if _, err := p.consumeTokenKind(TokenKindComma); err != nil {
+		if _, err := p.expectTokenKind(TokenKindComma); err != nil {
 			return nil, err
 		}
 	}
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return aliasList, nil
@@ -1039,7 +1039,7 @@ func (p *Parser) tryParseSampleClause(pos Pos) (*SampleClause, error) {
 }
 
 func (p *Parser) parseSampleClause(pos Pos) (*SampleClause, error) {
-	if err := p.consumeKeyword(KeywordSample); err != nil {
+	if err := p.expectKeyword(KeywordSample); err != nil {
 		return nil, err
 	}
 	ratio, err := p.parseRatioExpr(p.Pos())
@@ -1064,7 +1064,7 @@ func (p *Parser) parseSampleClause(pos Pos) (*SampleClause, error) {
 }
 
 func (p *Parser) parseExplainStmt(pos Pos) (*ExplainStmt, error) {
-	if err := p.consumeKeyword(KeywordExplain); err != nil {
+	if err := p.expectKeyword(KeywordExplain); err != nil {
 		return nil, err
 	}
 

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -69,7 +69,7 @@ func (p *Parser) parseDDL(pos Pos) (DDL, error) {
 }
 
 func (p *Parser) parseCreateDatabase(pos Pos) (*CreateDatabase, error) {
-	if err := p.consumeKeyword(KeywordDatabase); err != nil {
+	if err := p.expectKeyword(KeywordDatabase); err != nil {
 		return nil, err
 	}
 
@@ -113,7 +113,7 @@ func (p *Parser) parseCreateTable(pos Pos) (*CreateTable, error) {
 
 	createTable.HasTemporary = p.tryConsumeKeyword(KeywordTemporary) != nil
 
-	if err := p.consumeKeyword(KeywordTable); err != nil {
+	if err := p.expectKeyword(KeywordTable); err != nil {
 		return nil, err
 	}
 
@@ -295,7 +295,7 @@ func (p *Parser) parseTableSchemaClause(pos Pos) (*TableSchemaClause, error) {
 	switch {
 	case p.matchTokenKind(TokenKindLParen):
 		// parse column definitions
-		if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+		if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 			return nil, err
 		}
 
@@ -305,7 +305,7 @@ func (p *Parser) parseTableSchemaClause(pos Pos) (*TableSchemaClause, error) {
 		}
 
 		rightParenPos := p.Pos()
-		if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+		if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 			return nil, err
 		}
 		return &TableSchemaClause{
@@ -383,7 +383,7 @@ func (p *Parser) parseTableColumns() ([]Expr, error) {
 			if err != nil {
 				return nil, err
 			}
-			if err := p.consumeKeyword(KeywordCheck); err != nil {
+			if err := p.expectKeyword(KeywordCheck); err != nil {
 				return nil, err
 			}
 			expr, err := p.parseExpr(p.Pos())
@@ -539,7 +539,7 @@ func (p *Parser) parseTableArgExpr(pos Pos) (Expr, error) {
 }
 
 func (p *Parser) parseTableArgList(pos Pos) (*TableArgListExpr, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -556,7 +556,7 @@ func (p *Parser) parseTableArgList(pos Pos) (*TableArgListExpr, error) {
 	}
 
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 
@@ -571,7 +571,7 @@ func (p *Parser) tryParseClusterClause(pos Pos) (*ClusterClause, error) {
 	if p.tryConsumeKeyword(KeywordOn) == nil {
 		return nil, nil // nolint
 	}
-	if err := p.consumeKeyword(KeywordCluster); err != nil {
+	if err := p.expectKeyword(KeywordCluster); err != nil {
 		return nil, err
 	}
 
@@ -599,7 +599,7 @@ func (p *Parser) tryParsePartitionByClause(pos Pos) (*PartitionByClause, error) 
 		return nil, nil // nolint
 	}
 
-	if err := p.consumeKeyword(KeywordBy); err != nil {
+	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
 	}
 
@@ -619,7 +619,7 @@ func (p *Parser) tryParsePrimaryKeyClause(pos Pos) (*PrimaryKeyClause, error) {
 		return nil, nil // nolint
 	}
 
-	if err := p.consumeKeyword(KeywordKey); err != nil {
+	if err := p.expectKeyword(KeywordKey); err != nil {
 		return nil, err
 	}
 
@@ -639,7 +639,7 @@ func (p *Parser) tryParseOrderByClause(pos Pos) (*OrderByClause, error) {
 		return nil, nil // nolint
 	}
 
-	if err := p.consumeKeyword(KeywordBy); err != nil {
+	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
 	}
 	return p.parseOrderByClause(pos)
@@ -824,7 +824,7 @@ func (p *Parser) tryParseSampleByClause(pos Pos) (*SampleByClause, error) {
 		return nil, nil // nolint
 	}
 
-	if err := p.consumeKeyword(KeywordBy); err != nil {
+	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
 	}
 
@@ -874,7 +874,7 @@ func (p *Parser) parseSettingsExprList(pos Pos) (*SettingExprList, error) {
 		return nil, err
 	}
 
-	if _, err := p.consumeTokenKind(TokenKindSingleEQ); err != nil {
+	if _, err := p.expectTokenKind(TokenKindSingleEQ); err != nil {
 		return nil, err
 	}
 
@@ -910,7 +910,7 @@ func (p *Parser) parseSettingsExprList(pos Pos) (*SettingExprList, error) {
 }
 
 func (p *Parser) parseDestinationClause(pos Pos) (*DestinationClause, error) {
-	if err := p.consumeKeyword(KeywordTo); err != nil {
+	if err := p.expectKeyword(KeywordTo); err != nil {
 		return nil, err
 	}
 
@@ -932,7 +932,7 @@ func (p *Parser) tryParseEngineExpr(pos Pos) (*EngineExpr, error) {
 }
 
 func (p *Parser) parseEngineExpr(pos Pos) (*EngineExpr, error) {
-	if err := p.consumeKeyword(KeywordEngine); err != nil {
+	if err := p.expectKeyword(KeywordEngine); err != nil {
 		return nil, err
 	}
 	_ = p.tryConsumeTokenKind(TokenKindSingleEQ)
@@ -1082,7 +1082,7 @@ func (p *Parser) ParseStmts() ([]Expr, error) {
 }
 
 func (p *Parser) parseUseStmt(pos Pos) (*UseStmt, error) {
-	if err := p.consumeKeyword(KeywordUse); err != nil {
+	if err := p.expectKeyword(KeywordUse); err != nil {
 		return nil, err
 	}
 
@@ -1100,13 +1100,13 @@ func (p *Parser) parseUseStmt(pos Pos) (*UseStmt, error) {
 
 // syntax: TRUNCATE TEMPORARY? TABLE (IF EXISTS)? tableIdentifier clusterClause?;
 func (p *Parser) parseTruncateTable(pos Pos) (*TruncateTable, error) {
-	if err := p.consumeKeyword(KeywordTruncate); err != nil {
+	if err := p.expectKeyword(KeywordTruncate); err != nil {
 		return nil, err
 	}
 
 	isTemporary := p.tryConsumeKeyword(KeywordTemporary) != nil
 
-	if err := p.consumeKeyword(KeywordTable); err != nil {
+	if err := p.expectKeyword(KeywordTable); err != nil {
 		return nil, err
 	}
 
@@ -1142,10 +1142,10 @@ func (p *Parser) parseTruncateTable(pos Pos) (*TruncateTable, error) {
 }
 
 func (p *Parser) parseDeleteClause(pos Pos) (*DeleteClause, error) {
-	if err := p.consumeKeyword(KeywordDelete); err != nil {
+	if err := p.expectKeyword(KeywordDelete); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordFrom); err != nil {
+	if err := p.expectKeyword(KeywordFrom); err != nil {
 		return nil, err
 	}
 	tableIdentifier, err := p.parseTableIdentifier(p.Pos())
@@ -1157,7 +1157,7 @@ func (p *Parser) parseDeleteClause(pos Pos) (*DeleteClause, error) {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordWhere); err != nil {
+	if err := p.expectKeyword(KeywordWhere); err != nil {
 		return nil, err
 	}
 	whereExpr, err := p.parseExpr(p.Pos())
@@ -1174,7 +1174,7 @@ func (p *Parser) parseDeleteClause(pos Pos) (*DeleteClause, error) {
 }
 
 func (p *Parser) parseColumnNamesExpr(pos Pos) (*ColumnNamesExpr, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -1191,7 +1191,7 @@ func (p *Parser) parseColumnNamesExpr(pos Pos) (*ColumnNamesExpr, error) {
 		}
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 	return &ColumnNamesExpr{
@@ -1202,7 +1202,7 @@ func (p *Parser) parseColumnNamesExpr(pos Pos) (*ColumnNamesExpr, error) {
 }
 
 func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
-	if _, err := p.consumeTokenKind(TokenKindLParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
 	}
 
@@ -1225,7 +1225,7 @@ func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
 		}
 	}
 	rightParenPos := p.Pos()
-	if _, err := p.consumeTokenKind(TokenKindRParen); err != nil {
+	if _, err := p.expectTokenKind(TokenKindRParen); err != nil {
 		return nil, err
 	}
 
@@ -1237,10 +1237,10 @@ func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
 }
 
 func (p *Parser) parseInsertStmt(pos Pos) (*InsertStmt, error) {
-	if err := p.consumeKeyword(KeywordInsert); err != nil {
+	if err := p.expectKeyword(KeywordInsert); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordInto); err != nil {
+	if err := p.expectKeyword(KeywordInto); err != nil {
 		return nil, err
 	}
 	_ = p.tryConsumeKeyword(KeywordTable)
@@ -1305,7 +1305,7 @@ func (p *Parser) parseInsertStmt(pos Pos) (*InsertStmt, error) {
 }
 
 func (p *Parser) parseRenameStmt(pos Pos) (*RenameStmt, error) {
-	if err := p.consumeKeyword(KeywordRename); err != nil {
+	if err := p.expectKeyword(KeywordRename); err != nil {
 		return nil, err
 	}
 
@@ -1316,7 +1316,7 @@ func (p *Parser) parseRenameStmt(pos Pos) (*RenameStmt, error) {
 	case p.tryConsumeKeyword(KeywordDatabase) != nil:
 		renameTarget = KeywordDatabase
 	default:
-		if err := p.consumeKeyword(KeywordTable); err != nil {
+		if err := p.expectKeyword(KeywordTable); err != nil {
 			return nil, err
 		}
 	}
@@ -1359,7 +1359,7 @@ func (p *Parser) parseTargetPair(_ Pos) (*TargetPair, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = p.consumeKeyword(KeywordTo); err != nil {
+	if err = p.expectKeyword(KeywordTo); err != nil {
 		return nil, err
 	}
 	newTable, err := p.parseTableIdentifier(p.Pos())
@@ -1374,7 +1374,7 @@ func (p *Parser) parseTargetPair(_ Pos) (*TargetPair, error) {
 }
 
 func (p *Parser) parseCreateFunction(pos Pos) (*CreateFunction, error) {
-	if err := p.consumeKeyword(KeywordFunction); err != nil {
+	if err := p.expectKeyword(KeywordFunction); err != nil {
 		return nil, err
 	}
 	ifNotExists, err := p.tryParseIfNotExists()
@@ -1389,14 +1389,14 @@ func (p *Parser) parseCreateFunction(pos Pos) (*CreateFunction, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordAs); err != nil {
+	if err := p.expectKeyword(KeywordAs); err != nil {
 		return nil, err
 	}
 	params, err := p.parseFunctionParams(p.Pos())
 	if err != nil {
 		return nil, err
 	}
-	if _, err := p.consumeTokenKind(TokenKindArrow); err != nil {
+	if _, err := p.expectTokenKind(TokenKindArrow); err != nil {
 		return nil, err
 	}
 	expr, err := p.parseExpr(p.Pos())

--- a/parser/parser_view.go
+++ b/parser/parser_view.go
@@ -54,14 +54,15 @@ func (p *Parser) parseCreateMaterializedView(pos Pos) (*CreateMaterializedView, 
 		}
 		createMaterializedView.Engine = engineExpr
 		createMaterializedView.StatementEnd = engineExpr.End()
-		if populate := p.tryConsumeKeyword(KeywordPopulate); populate != nil {
+
+		if p.tryConsumeKeywords(KeywordPopulate) {
 			createMaterializedView.Populate = true
-			createMaterializedView.StatementEnd = populate.End
+			createMaterializedView.StatementEnd = p.Pos()
 		}
 	default:
 		return nil, fmt.Errorf("unexpected token: %q, expected TO or ENGINE", p.lastTokenKind())
 	}
-	if p.tryConsumeKeyword(KeywordAs) != nil {
+	if p.tryConsumeKeywords(KeywordAs) {
 		subQuery, err := p.parseSubQuery(p.Pos())
 		if err != nil {
 			return nil, err
@@ -117,7 +118,7 @@ func (p *Parser) parseCreateView(pos Pos) (*CreateView, error) {
 		createView.TableSchema = tableSchema
 	}
 
-	if p.tryConsumeKeyword(KeywordAs) != nil {
+	if p.tryConsumeKeywords(KeywordAs) {
 		subQuery, err := p.parseSubQuery(p.Pos())
 		if err != nil {
 			return nil, err
@@ -190,7 +191,7 @@ func (p *Parser) parseCreateLiveView(pos Pos) (*CreateLiveView, error) {
 		createLiveView.TableSchema = tableSchema
 	}
 
-	if p.tryConsumeKeyword(KeywordAs) != nil {
+	if p.tryConsumeKeywords(KeywordAs) {
 		subQuery, err := p.parseSubQuery(p.Pos())
 		if err != nil {
 			return nil, err
@@ -203,7 +204,7 @@ func (p *Parser) parseCreateLiveView(pos Pos) (*CreateLiveView, error) {
 }
 
 func (p *Parser) tryParseWithTimeout(pos Pos) (*WithTimeoutClause, error) {
-	if p.tryConsumeKeyword(KeywordWith) == nil {
+	if !p.tryConsumeKeywords(KeywordWith) {
 		return nil, nil // nolint
 	}
 	if err := p.expectKeyword(KeywordTimeout); err != nil {

--- a/parser/parser_view.go
+++ b/parser/parser_view.go
@@ -3,10 +3,10 @@ package parser
 import "fmt"
 
 func (p *Parser) parseCreateMaterializedView(pos Pos) (*CreateMaterializedView, error) {
-	if err := p.consumeKeyword(KeywordMaterialized); err != nil {
+	if err := p.expectKeyword(KeywordMaterialized); err != nil {
 		return nil, err
 	}
-	if err := p.consumeKeyword(KeywordView); err != nil {
+	if err := p.expectKeyword(KeywordView); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (p *Parser) parseCreateMaterializedView(pos Pos) (*CreateMaterializedView, 
 
 // (ATTACH | CREATE) (OR REPLACE)? VIEW (IF NOT EXISTS)? tableIdentifier uuidClause? clusterClause? tableSchemaClause? subqueryClause
 func (p *Parser) parseCreateView(pos Pos) (*CreateView, error) {
-	if err := p.consumeKeyword(KeywordView); err != nil {
+	if err := p.expectKeyword(KeywordView); err != nil {
 		return nil, err
 	}
 
@@ -133,11 +133,11 @@ func (p *Parser) parseCreateView(pos Pos) (*CreateView, error) {
 // (ATTACH | CREATE) LIVE VIEW (IF NOT EXISTS)? tableIdentifier uuidClause?
 // clusterClause? (WITH TIMEOUT DECIMAL_LITERAL?)? destinationClause? tableSchemaClause? subqueryClause
 func (p *Parser) parseCreateLiveView(pos Pos) (*CreateLiveView, error) {
-	if err := p.consumeKeyword(KeywordLive); err != nil {
+	if err := p.expectKeyword(KeywordLive); err != nil {
 		return nil, err
 	}
 
-	if err := p.consumeKeyword(KeywordView); err != nil {
+	if err := p.expectKeyword(KeywordView); err != nil {
 		return nil, err
 	}
 
@@ -206,7 +206,7 @@ func (p *Parser) tryParseWithTimeout(pos Pos) (*WithTimeoutClause, error) {
 	if p.tryConsumeKeyword(KeywordWith) == nil {
 		return nil, nil // nolint
 	}
-	if err := p.consumeKeyword(KeywordTimeout); err != nil {
+	if err := p.expectKeyword(KeywordTimeout); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- The first commit implements `tryConsumeWords` to allow consuming multiple keywords
- The second commit reanmes the `consumeKeyword` and `ConsumeTokenKind`
- The third commit replaces `tryConsumeWord` with `tryConsumeWords` because it's unnecessary to return the Token