### PR TITLE
Add support of the typed placeholder parameters for INSERT statement

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -3340,6 +3340,47 @@ func (w *WindowFunctionExpr) Accept(visitor ASTVisitor) error {
 	return visitor.VisitWindowFunctionExpr(w)
 }
 
+type TypedPlaceholder struct {
+	LeftBracePos  Pos
+	RightBracePos Pos
+	Name          *Ident
+	Type          ColumnType
+}
+
+func (t *TypedPlaceholder) Pos() Pos {
+	return t.LeftBracePos
+}
+
+func (t *TypedPlaceholder) End() Pos {
+	return t.RightBracePos
+}
+
+func (t *TypedPlaceholder) String() string {
+	var builder strings.Builder
+	builder.WriteString("{")
+	builder.WriteString(t.Name.String())
+	if t.Type != nil {
+		builder.WriteByte(':')
+		builder.WriteString(t.Type.String())
+	}
+	builder.WriteString("}")
+	return builder.String()
+}
+
+func (t *TypedPlaceholder) Accept(visitor ASTVisitor) error {
+	visitor.enter(t)
+	defer visitor.leave(t)
+	if err := t.Name.Accept(visitor); err != nil {
+		return err
+	}
+	if t.Type != nil {
+		if err := t.Type.Accept(visitor); err != nil {
+			return err
+		}
+	}
+	return visitor.VisitTypedPlaceholder(t)
+}
+
 type ColumnExpr struct {
 	Expr  Expr
 	Alias *Ident

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -3359,10 +3359,8 @@ func (t *TypedPlaceholder) String() string {
 	var builder strings.Builder
 	builder.WriteString("{")
 	builder.WriteString(t.Name.String())
-	if t.Type != nil {
-		builder.WriteByte(':')
-		builder.WriteString(t.Type.String())
-	}
+	builder.WriteByte(':')
+	builder.WriteString(t.Type.String())
 	builder.WriteString("}")
 	return builder.String()
 }
@@ -3373,10 +3371,8 @@ func (t *TypedPlaceholder) Accept(visitor ASTVisitor) error {
 	if err := t.Name.Accept(visitor); err != nil {
 		return err
 	}
-	if t.Type != nil {
-		if err := t.Type.Accept(visitor); err != nil {
-			return err
-		}
+	if err := t.Type.Accept(visitor); err != nil {
+		return err
 	}
 	return visitor.VisitTypedPlaceholder(t)
 }

--- a/parser/ast_visitor.go
+++ b/parser/ast_visitor.go
@@ -77,6 +77,7 @@ type ASTVisitor interface {
 	VisitWindowFunctionExpr(expr *WindowFunctionExpr) error
 	VisitColumnDef(expr *ColumnDef) error
 	VisitColumnExpr(expr *ColumnExpr) error
+	VisitTypedPlaceholder(expr *TypedPlaceholder) error
 	VisitScalarType(expr *ScalarType) error
 	VisitJSONType(expr *JSONType) error
 	VisitPropertyType(expr *PropertyType) error
@@ -705,6 +706,13 @@ func (v *DefaultASTVisitor) VisitColumnDef(expr *ColumnDef) error {
 }
 
 func (v *DefaultASTVisitor) VisitColumnExpr(expr *ColumnExpr) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitTypedPlaceholder(expr *TypedPlaceholder) error {
 	if v.Visit != nil {
 		return v.Visit(expr)
 	}

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -1202,7 +1202,7 @@ func (p *Parser) parseColumnNamesExpr(pos Pos) (*ColumnNamesExpr, error) {
 	}, nil
 }
 
-func (p *Parser) parseTypedPlaceHolder(pos Pos) (Expr, error) {
+func (p *Parser) parseTypedPlaceholder(pos Pos) (Expr, error) {
 	if _, err := p.expectTokenKind(TokenKindLBrace); err != nil {
 		return nil, err
 	}
@@ -1244,7 +1244,7 @@ func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
 			value, err = p.parseAssignmentValues(p.Pos())
 		case p.matchTokenKind(TokenKindLBrace):
 			// placeholder with type, e.g. {a :Int32}, {b :DateTime(6)}
-			value, err = p.parseTypedPlaceHolder(p.Pos())
+			value, err = p.parseTypedPlaceholder(p.Pos())
 		default:
 			value, err = p.parseExpr(p.Pos())
 		}

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -1202,6 +1202,34 @@ func (p *Parser) parseColumnNamesExpr(pos Pos) (*ColumnNamesExpr, error) {
 	}, nil
 }
 
+func (p *Parser) parseTypedPlaceHolder(pos Pos) (Expr, error) {
+	if _, err := p.expectTokenKind(TokenKindLBrace); err != nil {
+		return nil, err
+	}
+
+	name, err := p.parseIdent()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expectTokenKind(TokenKindColon); err != nil {
+		return nil, err
+	}
+	columnType, err := p.parseColumnType(p.Pos())
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := p.expectTokenKind(TokenKindRBrace); err != nil {
+		return nil, err
+	}
+	return &TypedPlaceholder{
+		LeftBracePos:  pos,
+		RightBracePos: p.Pos(),
+		Name:          name,
+		Type:          columnType,
+	}, nil
+}
+
 func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
 	if _, err := p.expectTokenKind(TokenKindLParen); err != nil {
 		return nil, err
@@ -1214,6 +1242,9 @@ func (p *Parser) parseAssignmentValues(pos Pos) (*AssignmentValues, error) {
 		switch {
 		case p.matchTokenKind(TokenKindLParen):
 			value, err = p.parseAssignmentValues(p.Pos())
+		case p.matchTokenKind(TokenKindLBrace):
+			// placeholder with type, e.g. {a :Int32}, {b :DateTime(6)}
+			value, err = p.parseTypedPlaceHolder(p.Pos())
 		default:
 			value, err = p.parseExpr(p.Pos())
 		}

--- a/parser/testdata/dml/format/insert_with_placeholder.sql
+++ b/parser/testdata/dml/format/insert_with_placeholder.sql
@@ -4,6 +4,11 @@ INSERT INTO t0(user_id, message, timestamp, metric) VALUES
     (?, ?, ?, ?),
     (?, ?, ?, ?),
     (?, ?, ?, ?)
+;
+
+INSERT INTO test_with_typed_columns (id, created_at)
+VALUES ({id: Int32}, {created_at: DateTime64(6)});
 
 -- Format SQL:
 INSERT INTO TABLE t0 (user_id, message, timestamp, metric) VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?);
+INSERT INTO TABLE test_with_typed_columns (id, created_at) VALUES ({id:Int32}, {created_at:DateTime64(6)});

--- a/parser/testdata/dml/insert_with_placeholder.sql
+++ b/parser/testdata/dml/insert_with_placeholder.sql
@@ -3,3 +3,7 @@ INSERT INTO t0(user_id, message, timestamp, metric) VALUES
     (?, ?, ?, ?),
     (?, ?, ?, ?),
     (?, ?, ?, ?)
+;
+
+INSERT INTO test_with_typed_columns (id, created_at)
+VALUES ({id: Int32}, {created_at: DateTime64(6)});

--- a/parser/testdata/dml/output/insert_with_placeholder.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_placeholder.sql.golden.json
@@ -160,5 +160,97 @@
       }
     ],
     "SelectExpr": null
+  },
+  {
+    "InsertPos": 133,
+    "Format": null,
+    "Table": {
+      "Database": null,
+      "Table": {
+        "Name": "test_with_typed_columns",
+        "QuoteType": 1,
+        "NamePos": 145,
+        "NameEnd": 168
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 169,
+      "RightParenPos": 184,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "id",
+            "QuoteType": 1,
+            "NamePos": 170,
+            "NameEnd": 172
+          },
+          "DotIdent": null
+        },
+        {
+          "Ident": {
+            "Name": "created_at",
+            "QuoteType": 1,
+            "NamePos": 174,
+            "NameEnd": 184
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": [
+      {
+        "LeftParenPos": 193,
+        "RightParenPos": 234,
+        "Values": [
+          {
+            "LeftBracePos": 194,
+            "RightBracePos": 205,
+            "Name": {
+              "Name": "id",
+              "QuoteType": 1,
+              "NamePos": 195,
+              "NameEnd": 197
+            },
+            "Type": {
+              "Name": {
+                "Name": "Int32",
+                "QuoteType": 1,
+                "NamePos": 199,
+                "NameEnd": 204
+              }
+            }
+          },
+          {
+            "LeftBracePos": 207,
+            "RightBracePos": 234,
+            "Name": {
+              "Name": "created_at",
+              "QuoteType": 1,
+              "NamePos": 208,
+              "NameEnd": 218
+            },
+            "Type": {
+              "LeftParenPos": 231,
+              "RightParenPos": 232,
+              "Name": {
+                "Name": "DateTime64",
+                "QuoteType": 1,
+                "NamePos": 220,
+                "NameEnd": 230
+              },
+              "Params": [
+                {
+                  "NumPos": 231,
+                  "NumEnd": 232,
+                  "Literal": "6",
+                  "Base": 10
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "SelectExpr": null
   }
 ]


### PR DESCRIPTION
The sample can refer to:

```SQL
INSERT INTO TABLE test_with_typed_columns (id, created_at) VALUES ({id:Int32}, {created_at:DateTime64(6)});
```