### PR TITLE
Fix INSERT INTO should allow the empty column list

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -6730,12 +6730,13 @@ func (v *AssignmentValues) Accept(visitor ASTVisitor) error {
 }
 
 type InsertStmt struct {
-	InsertPos   Pos
-	Format      *FormatClause
-	Table       Expr
-	ColumnNames *ColumnNamesExpr
-	Values      []*AssignmentValues
-	SelectExpr  *SelectQuery
+	InsertPos       Pos
+	Format          *FormatClause
+	HasTableKeyword bool
+	Table           Expr
+	ColumnNames     *ColumnNamesExpr
+	Values          []*AssignmentValues
+	SelectExpr      *SelectQuery
 }
 
 func (i *InsertStmt) Pos() Pos {
@@ -6751,7 +6752,10 @@ func (i *InsertStmt) End() Pos {
 
 func (i *InsertStmt) String() string {
 	var builder strings.Builder
-	builder.WriteString("INSERT INTO TABLE ")
+	builder.WriteString("INSERT INTO ")
+	if i.HasTableKeyword {
+		builder.WriteString("TABLE ")
+	}
 	builder.WriteString(i.Table.String())
 	if i.ColumnNames != nil {
 		builder.WriteString(" ")
@@ -6762,11 +6766,11 @@ func (i *InsertStmt) String() string {
 		builder.WriteString(i.Format.String())
 	}
 
-	builder.WriteString(" ")
 	if i.SelectExpr != nil {
+		builder.WriteString(" ")
 		builder.WriteString(i.SelectExpr.String())
-	} else {
-		builder.WriteString("VALUES ")
+	} else if len(i.Values) > 0 {
+		builder.WriteString(" VALUES ")
 		for j, value := range i.Values {
 			if j > 0 {
 				builder.WriteString(", ")

--- a/parser/testdata/dml/format/insert_values.sql
+++ b/parser/testdata/dml/format/insert_values.sql
@@ -6,4 +6,4 @@ INSERT INTO helloworld.my_first_table (user_id, message, timestamp, metric) VALU
     (101, 'Granules are the smallest chunks of data read',      now() + 5,   3.14159 )
 
 -- Format SQL:
-INSERT INTO TABLE helloworld.my_first_table (user_id, message, timestamp, metric) VALUES (101, 'Hello, ClickHouse!', now(), -1.0), (102, 'Insert a lot of rows per batch', yesterday(), 1.41421), (102, 'Sort your data based on your commonly-used queries', today(), 2.718), (101, 'Granules are the smallest chunks of data read', now() + 5, 3.14159);
+INSERT INTO helloworld.my_first_table (user_id, message, timestamp, metric) VALUES (101, 'Hello, ClickHouse!', now(), -1.0), (102, 'Insert a lot of rows per batch', yesterday(), 1.41421), (102, 'Sort your data based on your commonly-used queries', today(), 2.718), (101, 'Granules are the smallest chunks of data read', now() + 5, 3.14159);

--- a/parser/testdata/dml/format/insert_with_format.sql
+++ b/parser/testdata/dml/format/insert_with_format.sql
@@ -1,0 +1,11 @@
+-- Origin SQL:
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2`;
+INSERT INTO "db"."table_name" (col1, col2) VALUES (1, 2);
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2);
+INSERT INTO table_name (col1, col2) VALUES (1, 2) FORMAT Native;
+
+-- Format SQL:
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2`;
+INSERT INTO "db"."table_name" (col1, col2) VALUES (1, 2);
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2);
+INSERT INTO table_name (col1, col2) VALUES (1, 2);

--- a/parser/testdata/dml/format/insert_with_placeholder.sql
+++ b/parser/testdata/dml/format/insert_with_placeholder.sql
@@ -10,5 +10,5 @@ INSERT INTO test_with_typed_columns (id, created_at)
 VALUES ({id: Int32}, {created_at: DateTime64(6)});
 
 -- Format SQL:
-INSERT INTO TABLE t0 (user_id, message, timestamp, metric) VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?);
-INSERT INTO TABLE test_with_typed_columns (id, created_at) VALUES ({id:Int32}, {created_at:DateTime64(6)});
+INSERT INTO t0 (user_id, message, timestamp, metric) VALUES (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?), (?, ?, ?, ?);
+INSERT INTO test_with_typed_columns (id, created_at) VALUES ({id:Int32}, {created_at:DateTime64(6)});

--- a/parser/testdata/dml/format/insert_with_select.sql
+++ b/parser/testdata/dml/format/insert_with_select.sql
@@ -8,4 +8,4 @@ SELECT
 FROM test.visits;
 
 -- Format SQL:
-INSERT INTO TABLE test.visits_null SELECT CounterID, StartDate, Sign, UserID FROM test.visits;
+INSERT INTO test.visits_null SELECT CounterID, StartDate, Sign, UserID FROM test.visits;

--- a/parser/testdata/dml/insert_with_format.sql
+++ b/parser/testdata/dml/insert_with_format.sql
@@ -1,0 +1,4 @@
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2`;
+INSERT INTO "db"."table_name" (col1, col2) VALUES (1, 2);
+INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2);
+INSERT INTO table_name (col1, col2) VALUES (1, 2) FORMAT Native;

--- a/parser/testdata/dml/output/insert_values.sql.golden.json
+++ b/parser/testdata/dml/output/insert_values.sql.golden.json
@@ -2,6 +2,7 @@
   {
     "InsertPos": 0,
     "Format": null,
+    "HasTableKeyword": false,
     "Table": {
       "Database": {
         "Name": "helloworld",

--- a/parser/testdata/dml/output/insert_with_format.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_format.sql.golden.json
@@ -1,0 +1,192 @@
+[
+  {
+    "InsertPos": 0,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": {
+        "Name": "_test_1345# $.ДБ",
+        "QuoteType": 3,
+        "NamePos": 13,
+        "NameEnd": 31
+      },
+      "Table": {
+        "Name": "2. Таблица №2",
+        "QuoteType": 3,
+        "NamePos": 34,
+        "NameEnd": 56
+      }
+    },
+    "ColumnNames": null,
+    "Values": null,
+    "SelectExpr": null
+  },
+  {
+    "InsertPos": 59,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": {
+        "Name": "db",
+        "QuoteType": 2,
+        "NamePos": 72,
+        "NameEnd": 74
+      },
+      "Table": {
+        "Name": "table_name",
+        "QuoteType": 2,
+        "NamePos": 77,
+        "NameEnd": 87
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 89,
+      "RightParenPos": 100,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "col1",
+            "QuoteType": 1,
+            "NamePos": 90,
+            "NameEnd": 94
+          },
+          "DotIdent": null
+        },
+        {
+          "Ident": {
+            "Name": "col2",
+            "QuoteType": 1,
+            "NamePos": 96,
+            "NameEnd": 100
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": [
+      {
+        "LeftParenPos": 109,
+        "RightParenPos": 114,
+        "Values": [
+          {
+            "NumPos": 110,
+            "NumEnd": 111,
+            "Literal": "1",
+            "Base": 10
+          },
+          {
+            "NumPos": 113,
+            "NumEnd": 114,
+            "Literal": "2",
+            "Base": 10
+          }
+        ]
+      }
+    ],
+    "SelectExpr": null
+  },
+  {
+    "InsertPos": 117,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": {
+        "Name": "_test_1345# $.ДБ",
+        "QuoteType": 3,
+        "NamePos": 130,
+        "NameEnd": 148
+      },
+      "Table": {
+        "Name": "2. Таблица №2",
+        "QuoteType": 3,
+        "NamePos": 151,
+        "NameEnd": 173
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 175,
+      "RightParenPos": 186,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "col1",
+            "QuoteType": 1,
+            "NamePos": 176,
+            "NameEnd": 180
+          },
+          "DotIdent": null
+        },
+        {
+          "Ident": {
+            "Name": "col2",
+            "QuoteType": 1,
+            "NamePos": 182,
+            "NameEnd": 186
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": null,
+    "SelectExpr": null
+  },
+  {
+    "InsertPos": 189,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": null,
+      "Table": {
+        "Name": "table_name",
+        "QuoteType": 1,
+        "NamePos": 201,
+        "NameEnd": 211
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 212,
+      "RightParenPos": 223,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "col1",
+            "QuoteType": 1,
+            "NamePos": 213,
+            "NameEnd": 217
+          },
+          "DotIdent": null
+        },
+        {
+          "Ident": {
+            "Name": "col2",
+            "QuoteType": 1,
+            "NamePos": 219,
+            "NameEnd": 223
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": [
+      {
+        "LeftParenPos": 232,
+        "RightParenPos": 237,
+        "Values": [
+          {
+            "NumPos": 233,
+            "NumEnd": 234,
+            "Literal": "1",
+            "Base": 10
+          },
+          {
+            "NumPos": 236,
+            "NumEnd": 237,
+            "Literal": "2",
+            "Base": 10
+          }
+        ]
+      }
+    ],
+    "SelectExpr": null
+  }
+]

--- a/parser/testdata/dml/output/insert_with_placeholder.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_placeholder.sql.golden.json
@@ -2,6 +2,7 @@
   {
     "InsertPos": 0,
     "Format": null,
+    "HasTableKeyword": false,
     "Table": {
       "Database": null,
       "Table": {
@@ -164,6 +165,7 @@
   {
     "InsertPos": 133,
     "Format": null,
+    "HasTableKeyword": false,
     "Table": {
       "Database": null,
       "Table": {

--- a/parser/testdata/dml/output/insert_with_select.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_select.sql.golden.json
@@ -2,6 +2,7 @@
   {
     "InsertPos": 0,
     "Format": null,
+    "HasTableKeyword": false,
     "Table": {
       "Database": {
         "Name": "test",


### PR DESCRIPTION
The following syntax is valid in ClickHouse:

```SQL
INSERT INTO table_name
```