### PR TITLE
[ Bug Fix ] Preserve DISTINCT keyword when it appears right after SELECT

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -5694,6 +5694,7 @@ type SelectQuery struct {
 	StatementEnd  Pos
 	With          *WithClause
 	Top           *TopClause
+	HasDistinct   bool
 	SelectItems   []*SelectItem
 	From          *FromClause
 	ArrayJoin     *ArrayJoinClause
@@ -5735,6 +5736,9 @@ func (s *SelectQuery) String() string { // nolint: funlen
 		builder.WriteString(" ")
 	}
 	builder.WriteString("SELECT ")
+	if s.HasDistinct {
+		builder.WriteString("DISTINCT ")
+	}
 	if s.Top != nil {
 		builder.WriteString(s.Top.String())
 		builder.WriteString(" ")

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -834,7 +834,7 @@ func (p *Parser) parseSelectStmt(pos Pos) (*SelectQuery, error) { // nolint: fun
 		return nil, err
 	}
 	// DISTINCT?
-	_ = p.tryConsumeKeywords(KeywordDistinct)
+	hasDistinct := p.tryConsumeKeywords(KeywordDistinct)
 
 	top, err := p.tryParseTopClause(p.Pos())
 	if err != nil {
@@ -961,6 +961,7 @@ func (p *Parser) parseSelectStmt(pos Pos) (*SelectQuery, error) { // nolint: fun
 		SelectPos:    pos,
 		StatementEnd: statementEnd,
 		Top:          top,
+		HasDistinct:  hasDistinct,
 		SelectItems:  selectItems,
 		From:         from,
 		ArrayJoin:    arrayJoin,

--- a/parser/testdata/ddl/output/bug_001.sql.golden.json
+++ b/parser/testdata/ddl/output/bug_001.sql.golden.json
@@ -57,6 +57,7 @@
         "StatementEnd": 635,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_live_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_live_view_basic.sql.golden.json
@@ -82,6 +82,7 @@
         "StatementEnd": 101,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
@@ -254,6 +254,7 @@
         "StatementEnd": 537,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_materialized_view_with_definer.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_definer.sql.golden.json
@@ -180,6 +180,7 @@
         "StatementEnd": 355,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
@@ -151,6 +151,7 @@
         "StatementEnd": 460,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {
@@ -245,6 +246,7 @@
                     "StatementEnd": 433,
                     "With": null,
                     "Top": null,
+                    "HasDistinct": false,
                     "SelectItems": [
                       {
                         "Expr": {

--- a/parser/testdata/ddl/output/create_materialized_view_with_refresh.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_refresh.sql.golden.json
@@ -147,6 +147,7 @@
         "StatementEnd": 302,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_mv_with_not_op.sql.golden.json
+++ b/parser/testdata/ddl/output/create_mv_with_not_op.sql.golden.json
@@ -254,6 +254,7 @@
         "StatementEnd": 559,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_mv_with_order_by.sql.golden.json
+++ b/parser/testdata/ddl/output/create_mv_with_order_by.sql.golden.json
@@ -103,6 +103,7 @@
         "StatementEnd": 135,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {
@@ -233,6 +234,7 @@
         "StatementEnd": 259,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_or_replace.sql.golden.json
+++ b/parser/testdata/ddl/output/create_or_replace.sql.golden.json
@@ -413,6 +413,7 @@
         "StatementEnd": 508,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_basic.sql.golden.json
@@ -90,6 +90,7 @@
         "StatementEnd": 104,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
@@ -41,6 +41,7 @@
         "StatementEnd": 199,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/dml/output/insert_with_select.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_select.sql.golden.json
@@ -24,6 +24,7 @@
       "StatementEnd": 103,
       "With": null,
       "Top": null,
+      "HasDistinct": false,
       "SelectItems": [
         {
           "Expr": {

--- a/parser/testdata/query/format/select_with_distinct_keyword.sql
+++ b/parser/testdata/query/format/select_with_distinct_keyword.sql
@@ -1,0 +1,5 @@
+-- Origin SQL:
+SELECT DISTINCT record_id FROM records 
+
+-- Format SQL:
+SELECT DISTINCT record_id FROM records;

--- a/parser/testdata/query/output/access_tuple_with_dot.sql.golden.json
+++ b/parser/testdata/query/output/access_tuple_with_dot.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 34,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -95,6 +96,7 @@
     "StatementEnd": 336,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/query_with_expr_compare.sql.golden.json
+++ b/parser/testdata/query/output/query_with_expr_compare.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 225,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -108,6 +109,7 @@
               "StatementEnd": 121,
               "With": null,
               "Top": null,
+              "HasDistinct": false,
               "SelectItems": [
                 {
                   "Expr": {

--- a/parser/testdata/query/output/select_cast.sql.golden.json
+++ b/parser/testdata/query/output/select_cast.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 34,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -56,6 +57,7 @@
     "StatementEnd": 70,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -105,6 +107,7 @@
     "StatementEnd": 102,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -164,6 +167,7 @@
     "StatementEnd": 130,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_column_alias_string.sql.golden.json
+++ b/parser/testdata/query/output/select_column_alias_string.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 23,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -42,6 +43,7 @@
     "StatementEnd": 52,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_expr.sql.golden.json
+++ b/parser/testdata/query/output/select_expr.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 10,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_item_with_modifiers.sql.golden.json
+++ b/parser/testdata/query/output/select_item_with_modifiers.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 35,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -95,6 +96,7 @@
     "StatementEnd": 73,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -197,6 +199,7 @@
     "StatementEnd": 133,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple.sql.golden.json
+++ b/parser/testdata/query/output/select_simple.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 277,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_field_alias.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_field_alias.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 48,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_bracket.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_bracket.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 66,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_cte_with_column_aliases.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_cte_with_column_aliases.sql.golden.json
@@ -60,6 +60,7 @@
             "StatementEnd": 58,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -135,6 +136,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_group_by_with_cube_totals.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_group_by_with_cube_totals.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 86,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_is_not_null.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_is_not_null.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 133,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_is_null.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_is_null.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 112,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_top_clause.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_top_clause.sql.golden.json
@@ -14,6 +14,7 @@
       },
       "WithTies": false
     },
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_simple_with_with_clause.sql.golden.json
+++ b/parser/testdata/query/output/select_simple_with_with_clause.sql.golden.json
@@ -19,6 +19,7 @@
             "StatementEnd": 35,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -84,6 +85,7 @@
             "StatementEnd": 68,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -139,6 +141,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_table_alias_without_keyword.sql.golden.json
+++ b/parser/testdata/query/output/select_table_alias_without_keyword.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 36,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_table_function_with_query.sql.golden.json
+++ b/parser/testdata/query/output/select_table_function_with_query.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 125,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -23,6 +24,7 @@
             "StatementEnd": 20,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -119,6 +121,7 @@
                                 "StatementEnd": 105,
                                 "With": null,
                                 "Top": null,
+                                "HasDistinct": false,
                                 "SelectItems": [
                                   {
                                     "Expr": {

--- a/parser/testdata/query/output/select_when_condition.sql.golden.json
+++ b/parser/testdata/query/output/select_when_condition.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 0,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_distinct.sql.golden.json
+++ b/parser/testdata/query/output/select_with_distinct.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 51,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_distinct_keyword.sql.golden.json
+++ b/parser/testdata/query/output/select_with_distinct_keyword.sql.golden.json
@@ -1,41 +1,41 @@
 [
   {
     "SelectPos": 0,
-    "StatementEnd": 47,
+    "StatementEnd": 38,
     "With": null,
     "Top": null,
-    "HasDistinct": false,
+    "HasDistinct": true,
     "SelectItems": [
       {
         "Expr": {
-          "Name": "Timestamp",
+          "Name": "record_id",
           "QuoteType": 1,
-          "NamePos": 7,
-          "NameEnd": 16
+          "NamePos": 16,
+          "NameEnd": 25
         },
         "Modifiers": [],
         "Alias": null
       }
     ],
     "From": {
-      "FromPos": 17,
+      "FromPos": 26,
       "Expr": {
         "Table": {
-          "TablePos": 22,
-          "TableEnd": 28,
+          "TablePos": 31,
+          "TableEnd": 38,
           "Alias": null,
           "Expr": {
             "Database": null,
             "Table": {
-              "Name": "events",
+              "Name": "records",
               "QuoteType": 1,
-              "NamePos": 22,
-              "NameEnd": 28
+              "NamePos": 31,
+              "NameEnd": 38
             }
           },
           "HasFinal": false
         },
-        "StatementEnd": 28,
+        "StatementEnd": 38,
         "SampleRatio": null,
         "HasFinal": false
       }
@@ -47,23 +47,7 @@
     "GroupBy": null,
     "WithTotal": false,
     "Having": null,
-    "OrderBy": {
-      "OrderPos": 29,
-      "ListEnd": 47,
-      "Items": [
-        {
-          "OrderPos": 29,
-          "Expr": {
-            "Name": "Timestamp",
-            "QuoteType": 1,
-            "NamePos": 38,
-            "NameEnd": 47
-          },
-          "Alias": null,
-          "Direction": ""
-        }
-      ]
-    },
+    "OrderBy": null,
     "LimitBy": null,
     "Limit": null,
     "Settings": null,

--- a/parser/testdata/query/output/select_with_group_by.sql.golden.json
+++ b/parser/testdata/query/output/select_with_group_by.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 171,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -222,6 +223,7 @@
     "StatementEnd": 264,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_join_only.sql.golden.json
+++ b/parser/testdata/query/output/select_with_join_only.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 17,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_keyword_in_group_by.sql.golden.json
+++ b/parser/testdata/query/output/select_with_keyword_in_group_by.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 181,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_left_join.sql.golden.json
+++ b/parser/testdata/query/output/select_with_left_join.sql.golden.json
@@ -19,6 +19,7 @@
             "StatementEnd": 54,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -67,6 +68,7 @@
             "StatementEnd": 98,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -105,6 +107,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_literal_table_name.sql.golden.json
+++ b/parser/testdata/query/output/select_with_literal_table_name.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 60,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_multi_join.sql.golden.json
+++ b/parser/testdata/query/output/select_with_multi_join.sql.golden.json
@@ -19,6 +19,7 @@
             "StatementEnd": 41,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -66,6 +67,7 @@
             "StatementEnd": 81,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -113,6 +115,7 @@
             "StatementEnd": 121,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -150,6 +153,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_multi_line_comment.sql.golden.json
+++ b/parser/testdata/query/output/select_with_multi_line_comment.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 61,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_multi_union.sql.golden.json
+++ b/parser/testdata/query/output/select_with_multi_union.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 14,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -39,6 +40,7 @@
       "StatementEnd": 39,
       "With": null,
       "Top": null,
+      "HasDistinct": false,
       "SelectItems": [
         {
           "Expr": {
@@ -74,6 +76,7 @@
         "StatementEnd": 64,
         "With": null,
         "Top": null,
+        "HasDistinct": false,
         "SelectItems": [
           {
             "Expr": {

--- a/parser/testdata/query/output/select_with_number_field.sql.golden.json
+++ b/parser/testdata/query/output/select_with_number_field.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 53,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_placeholder.sql.golden.json
+++ b/parser/testdata/query/output/select_with_placeholder.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 28,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_query_parameter.sql.golden.json
+++ b/parser/testdata/query/output/select_with_query_parameter.sql.golden.json
@@ -170,6 +170,7 @@
     "StatementEnd": 218,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -314,6 +315,7 @@
     "StatementEnd": 283,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_string_expr.sql.golden.json
+++ b/parser/testdata/query/output/select_with_string_expr.sql.golden.json
@@ -19,6 +19,7 @@
             "StatementEnd": 28,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -57,6 +58,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_union_distinct.sql.golden.json
+++ b/parser/testdata/query/output/select_with_union_distinct.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 43,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {
@@ -62,6 +63,7 @@
       "StatementEnd": 121,
       "With": null,
       "Top": null,
+      "HasDistinct": false,
       "SelectItems": [
         {
           "Expr": {

--- a/parser/testdata/query/output/select_with_variable.sql.golden.json
+++ b/parser/testdata/query/output/select_with_variable.sql.golden.json
@@ -19,6 +19,7 @@
             "StatementEnd": 27,
             "With": null,
             "Top": null,
+            "HasDistinct": false,
             "SelectItems": [
               {
                 "Expr": {
@@ -57,6 +58,7 @@
       ]
     },
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/output/select_with_window_function.sql.golden.json
+++ b/parser/testdata/query/output/select_with_window_function.sql.golden.json
@@ -4,6 +4,7 @@
     "StatementEnd": 348,
     "With": null,
     "Top": null,
+    "HasDistinct": false,
     "SelectItems": [
       {
         "Expr": {

--- a/parser/testdata/query/select_with_distinct_keyword.sql
+++ b/parser/testdata/query/select_with_distinct_keyword.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT record_id FROM records 


### PR DESCRIPTION
## Description
This PR fixes a bug in the SQL parser where the `DISTINCT` keyword was being lost during parsing and reconstruction when it appears right after the `SELECT` keyword. For example:

```sql
-- Before: This would lose the DISTINCT keyword
SELECT DISTINCT record_id FROM records
-- Would become:
SELECT record_id FROM records

-- After: The DISTINCT keyword is preserved
SELECT DISTINCT record_id FROM records
-- Remains as:
SELECT DISTINCT record_id FROM records
```

Note that this fix only affects the case where `DISTINCT` appears right after `SELECT`. The parser already correctly handles `DISTINCT` in other contexts, such as in aggregate functions:

```sql
SELECT count(DISTINCT(RECORD_ID)) FROM RECORD_TABLE
```

## Changes
- Added `HasDistinct` field to `SelectQuery` struct
- Modified `parseSelectStmt` to store the DISTINCT information
- Updated `String()` method to include DISTINCT in the output
- Added test cases to verify the fix

## Testing
Added test cases to verify that:
1. `SELECT DISTINCT record_id FROM records` preserves the DISTINCT keyword
2. `SELECT count(DISTINCT(RECORD_ID)) FROM RECORD_TABLE` continues to work as before