### PR TITLE
Add MILLISECOND to time interval units

### DIFF
--- a/parser/type.go
+++ b/parser/type.go
@@ -1,3 +1,3 @@
 package parser
 
-var intervalUnits = NewSet("SECOND", "MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "QUARTER", "YEAR")
+var intervalUnits = NewSet("MILLISECOND", "SECOND", "MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "QUARTER", "YEAR")


### PR DESCRIPTION
This PR extends the parser to recognize MILLISECOND as a valid interval unit.