### PR TITLE
fix: ParamExprList.String is missing ColumnArgList

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -3266,6 +3266,9 @@ func (f *ParamExprList) String() string {
 	builder.WriteString("(")
 	builder.WriteString(f.Items.String())
 	builder.WriteString(")")
+	if f.ColumnArgList != nil {
+	    builder.WriteString(f.ColumnArgList.String())
+	}
 	return builder.String()
 }
 

--- a/parser/testdata/basic/format/quantile_functions.sql
+++ b/parser/testdata/basic/format/quantile_functions.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT quantile(0.9)(x), quantiles(0.5, 0.9)(x);
+
+
+-- Format SQL:
+SELECT quantile(0.9)(x), quantiles(0.5, 0.9)(x);

--- a/parser/testdata/basic/output/quantile_functions.sql.golden.json
+++ b/parser/testdata/basic/output/quantile_functions.sql.golden.json
@@ -1,0 +1,126 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 43,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": {
+            "Name": "quantile",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 15
+          },
+          "Params": {
+            "LeftParenPos": 15,
+            "RightParenPos": 19,
+            "Items": {
+              "ListPos": 16,
+              "ListEnd": 19,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 16,
+                    "NumEnd": 19,
+                    "Literal": "0.9",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": {
+              "Distinct": false,
+              "LeftParenPos": 20,
+              "RightParenPos": 22,
+              "Items": [
+                {
+                  "Name": "x",
+                  "QuoteType": 1,
+                  "NamePos": 21,
+                  "NameEnd": 22
+                }
+              ]
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Name": {
+            "Name": "quantiles",
+            "QuoteType": 1,
+            "NamePos": 25,
+            "NameEnd": 34
+          },
+          "Params": {
+            "LeftParenPos": 34,
+            "RightParenPos": 43,
+            "Items": {
+              "ListPos": 35,
+              "ListEnd": 43,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 35,
+                    "NumEnd": 38,
+                    "Literal": "0.5",
+                    "Base": 10
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "NumPos": 40,
+                    "NumEnd": 43,
+                    "Literal": "0.9",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": {
+              "Distinct": false,
+              "LeftParenPos": 44,
+              "RightParenPos": 46,
+              "Items": [
+                {
+                  "Name": "x",
+                  "QuoteType": 1,
+                  "NamePos": 45,
+                  "NameEnd": 46
+                }
+              ]
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/basic/quantile_functions.sql
+++ b/parser/testdata/basic/quantile_functions.sql
@@ -1,0 +1,1 @@
+SELECT quantile(0.9)(x), quantiles(0.5, 0.9)(x);


### PR DESCRIPTION
`String` method of type `ParamExprList` does not print the value of its member `ColumnArgList`, which causes the quantile expression like `quantile(0.5)(x)` drops the second parameter list `(x)`. This patch fixes this bug.