### PR TITLE
fix: Fix `Walk` logic for `When` clause

### DIFF
--- a/parser/walk.go
+++ b/parser/walk.go
@@ -138,7 +138,7 @@ func Walk(node Expr, fn WalkFunc) bool {
 			return false
 		}
 	case *WhenClause:
-		if Walk(n.When, fn) {
+		if !Walk(n.When, fn) {
 			return false
 		}
 		if !Walk(n.Then, fn) {


### PR DESCRIPTION
Thank you for this lovely module, this PR fixes a bug in the `Walk` function where it stops prematurely on `WhenClause`