### PR TITLE
fix: Allow using keywords as alias for columns

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -744,12 +744,18 @@ func (p *Parser) parseSelectItem() (*SelectItem, error) {
 	}
 
 	var alias *Ident
-	if p.tryConsumeKeywords(KeywordAs) {
+	switch {
+	case p.tryConsumeKeywords(KeywordAs):
 		alias, err = p.parseIdent()
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	case p.lastTokenKind() == TokenKindKeyword && !p.matchKeyword(KeywordFrom):
+		alias, err = p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+	default:
 		alias = p.tryParseIdent()
 	}
 

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -1009,34 +1009,6 @@ func (p *Parser) parseCTEStmt(pos Pos) (*CTEStmt, error) {
 	}, nil
 }
 
-func (p *Parser) tryParseColumnAliases() ([]*Ident, error) {
-	if !p.matchTokenKind(TokenKindLParen) {
-		return nil, nil
-	}
-	if err := p.expectTokenKind(TokenKindLParen); err != nil {
-		return nil, err
-	}
-
-	aliasList := make([]*Ident, 0)
-	for {
-		ident, err := p.parseIdent()
-		if err != nil {
-			return nil, err
-		}
-		aliasList = append(aliasList, ident)
-		if p.matchTokenKind(TokenKindRParen) {
-			break
-		}
-		if err := p.expectTokenKind(TokenKindComma); err != nil {
-			return nil, err
-		}
-	}
-	if err := p.expectTokenKind(TokenKindRParen); err != nil {
-		return nil, err
-	}
-	return aliasList, nil
-}
-
 func (p *Parser) tryParseSampleClause(pos Pos) (*SampleClause, error) {
 	if !p.matchKeyword(KeywordSample) {
 		return nil, nil

--- a/parser/testdata/query/format/select_keyword_alias_no_as.sql
+++ b/parser/testdata/query/format/select_keyword_alias_no_as.sql
@@ -1,0 +1,5 @@
+-- Origin SQL:
+SELECT 'Joe' name FROM users
+
+-- Format SQL:
+SELECT 'Joe' AS name FROM users;

--- a/parser/testdata/query/output/select_keyword_alias_no_as.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_alias_no_as.sql.golden.json
@@ -1,0 +1,63 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 28,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LiteralPos": 8,
+          "LiteralEnd": 11,
+          "Literal": "Joe"
+        },
+        "Modifiers": [],
+        "Alias": {
+          "Name": "name",
+          "QuoteType": 1,
+          "NamePos": 13,
+          "NameEnd": 17
+        }
+      }
+    ],
+    "From": {
+      "FromPos": 18,
+      "Expr": {
+        "Table": {
+          "TablePos": 23,
+          "TableEnd": 28,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "users",
+              "QuoteType": 1,
+              "NamePos": 23,
+              "NameEnd": 28
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 28,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_keyword_alias_no_as.sql
+++ b/parser/testdata/query/select_keyword_alias_no_as.sql
@@ -1,0 +1,1 @@
+SELECT 'Joe' name FROM users


### PR DESCRIPTION
This fix is similar to https://github.com/AfterShip/clickhouse-sql-parser/pull/148, to allow using a keyword as a column alias, as `SELECT 'Joe' name FROM users` is valid (you can check on https://sql.clickhouse.com?query=U0VMRUNUICdKb2UnIG5hbWUgRlJPTSBvdGVsLm90ZWxfbG9ncw)