### PR TITLE
Parse compression codecs with no parameters

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1142,13 +1142,15 @@ func (p *Parser) tryParseCompressionCodecs(pos Pos) (*CompressionCodec, error) {
 		if err != nil {
 			return nil, err
 		}
-		// consume comma
-		if err := p.expectTokenKind(TokenKindComma); err != nil {
-			return nil, err
-		}
-		name, err = p.parseIdent()
-		if err != nil {
-			return nil, err
+
+		if p.matchTokenKind(TokenKindComma) {
+			if err := p.expectTokenKind(TokenKindComma); err != nil {
+				return nil, err
+			}
+			name, err = p.parseIdent()
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/parser/testdata/ddl/create_table_codec_no_args.sql
+++ b/parser/testdata/ddl/create_table_codec_no_args.sql
@@ -1,0 +1,3 @@
+CREATE TABLE shark_attacks (
+    timestamp DateTime CODEC(DoubleDelta),
+);

--- a/parser/testdata/ddl/format/create_table_codec_no_args.sql
+++ b/parser/testdata/ddl/format/create_table_codec_no_args.sql
@@ -1,0 +1,7 @@
+-- Origin SQL:
+CREATE TABLE shark_attacks (
+    timestamp DateTime CODEC(DoubleDelta),
+);
+
+-- Format SQL:
+CREATE TABLE shark_attacks (timestamp DateTime CODEC(DoubleDelta, DoubleDelta));

--- a/parser/testdata/ddl/output/create_table_codec_no_args.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_codec_no_args.sql.golden.json
@@ -1,0 +1,78 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 0,
+    "OrReplace": false,
+    "Name": {
+      "Database": null,
+      "Table": {
+        "Name": "shark_attacks",
+        "QuoteType": 1,
+        "NamePos": 13,
+        "NameEnd": 26
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "TableSchema": {
+      "SchemaPos": 27,
+      "SchemaEnd": 72,
+      "Columns": [
+        {
+          "NamePos": 33,
+          "ColumnEnd": 70,
+          "Name": {
+            "Ident": {
+              "Name": "timestamp",
+              "QuoteType": 1,
+              "NamePos": 33,
+              "NameEnd": 42
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "DateTime",
+              "QuoteType": 1,
+              "NamePos": 43,
+              "NameEnd": 51
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": {
+            "CodecPos": 52,
+            "RightParenPos": 70,
+            "Type": {
+              "Name": "DoubleDelta",
+              "QuoteType": 1,
+              "NamePos": 58,
+              "NameEnd": 69
+            },
+            "TypeLevel": null,
+            "Name": {
+              "Name": "DoubleDelta",
+              "QuoteType": 1,
+              "NamePos": 58,
+              "NameEnd": 69
+            },
+            "Level": null
+          },
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        }
+      ],
+      "AliasTable": null,
+      "TableFunction": null
+    },
+    "Engine": null,
+    "SubQuery": null,
+    "HasTemporary": false,
+    "Comment": null
+  }
+]


### PR DESCRIPTION
Compression codecs such as `DoubleDelta` do not require any additional positional parameters and infer defaults, such as `CODEC(DoubleDelta)`. This commit doesn't continue parsing a codec if there's not a comma indicating additional parameters to the codec.