### PR TITLE
fix: Support single-quoted table names.

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -1545,10 +1545,13 @@ func (i *Ident) End() Pos {
 }
 
 func (i *Ident) String() string {
-	if i.QuoteType == BackTicks {
+	switch i.QuoteType {
+	case BackTicks:
 		return "`" + i.Name + "`"
-	} else if i.QuoteType == DoubleQuote {
+	case DoubleQuote:
 		return `"` + i.Name + `"`
+	case SingleQuote:
+		return `'` + i.Name + `'`
 	}
 	return i.Name
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -50,6 +50,7 @@ const (
 	Unquoted = iota + 1
 	DoubleQuote
 	BackTicks
+	SingleQuote
 )
 
 type Pos int

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -142,11 +142,36 @@ func (p *Parser) parseIdentOrStar() (*Ident, error) {
 	}
 }
 
+func (p *Parser) parseIdentOrString() (*Ident, error) {
+	switch {
+	case p.matchTokenKind(TokenKindIdent):
+		return p.parseIdent()
+	case p.matchTokenKind(TokenKindString):
+		lastToken := p.last()
+		_ = p.lexer.consumeToken()
+		return &Ident{
+			NamePos:   lastToken.Pos,
+			NameEnd:   lastToken.End,
+			Name:      lastToken.String,
+			QuoteType: SingleQuote, // Treat string literals as single-quoted identifiers
+		}, nil
+	default:
+		return nil, fmt.Errorf("expected <ident> or <string>, but got %q", p.lastTokenKind())
+	}
+}
+
 func (p *Parser) tryParseDotIdent(_ Pos) (*Ident, error) {
 	if p.tryConsumeTokenKind(TokenKindDot) == nil {
 		return nil, nil // nolint
 	}
 	return p.parseIdent()
+}
+
+func (p *Parser) tryParseDotIdentOrString(_ Pos) (*Ident, error) {
+	if p.tryConsumeTokenKind(TokenKindDot) == nil {
+		return nil, nil // nolint
+	}
+	return p.parseIdentOrString()
 }
 
 func (p *Parser) parseUUID() (*UUID, error) {

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -230,7 +230,7 @@ func (p *Parser) parseJoinOp(_ Pos) []string {
 
 func (p *Parser) parseJoinTableExpr(_ Pos) (Expr, error) {
 	switch {
-	case p.matchTokenKind(TokenKindIdent), p.matchTokenKind(TokenKindLParen):
+	case p.matchTokenKind(TokenKindIdent), p.matchTokenKind(TokenKindString), p.matchTokenKind(TokenKindLParen):
 		tableExpr, err := p.parseTableExpr(p.Pos())
 		if err != nil {
 			return nil, err

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -331,11 +331,11 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 }
 
 func (p *Parser) parseTableIdentifier(_ Pos) (*TableIdentifier, error) {
-	ident, err := p.parseIdent()
+	ident, err := p.parseIdentOrString()
 	if err != nil {
 		return nil, err
 	}
-	dotIdent, err := p.tryParseDotIdent(p.Pos())
+	dotIdent, err := p.tryParseDotIdentOrString(p.Pos())
 	if err != nil {
 		return nil, err
 	}

--- a/parser/testdata/query/format/select_with_single_quote_table.sql
+++ b/parser/testdata/query/format/select_with_single_quote_table.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT * FROM 'test_table'
+
+
+-- Format SQL:
+SELECT * FROM 'test_table';

--- a/parser/testdata/query/output/select_with_single_quote_table.sql.golden.json
+++ b/parser/testdata/query/output/select_with_single_quote_table.sql.golden.json
@@ -1,0 +1,60 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 25,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 7,
+          "NameEnd": 7
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 9,
+      "Expr": {
+        "Table": {
+          "TablePos": 15,
+          "TableEnd": 25,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "test_table",
+              "QuoteType": 4,
+              "NamePos": 15,
+              "NameEnd": 25
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 25,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_with_single_quote_table.sql
+++ b/parser/testdata/query/select_with_single_quote_table.sql
@@ -1,0 +1,1 @@
+SELECT * FROM 'test_table'


### PR DESCRIPTION
The ClickHouse console allows one to quote table names using single quotes:

<img width="386" height="792" alt="Screenshot 2025-10-02 at 16 19 25" src="https://github.com/user-attachments/assets/342062ca-d50f-4e0b-9884-77be8162c39c" />

The parser does not:

<img width="838" height="558" alt="Screenshot 2025-10-02 at 16 21 55" src="https://github.com/user-attachments/assets/8416289e-a421-42ac-9104-845e79c6d37b" />

This PR implements support for this. Adds test for it; all other tests continue to pass.