### PR TITLE
parser: fix typed placeholder lookahead; parse WHERE in SELECT without FROM

### DIFF
--- a/parser/testdata/dml/format/insert_select_without_from.sql
+++ b/parser/testdata/dml/format/insert_select_without_from.sql
@@ -1,0 +1,7 @@
+-- Origin SQL:
+INSERT INTO t (c) SELECT 1 WHERE 1 = 1;
+
+
+
+-- Format SQL:
+INSERT INTO t (c) SELECT 1 WHERE 1 = 1;

--- a/parser/testdata/dml/format/insert_with_keyword_placeholder.sql
+++ b/parser/testdata/dml/format/insert_with_keyword_placeholder.sql
@@ -1,0 +1,7 @@
+-- Origin SQL:
+INSERT INTO t (c) VALUES ({name :String});
+
+
+
+-- Format SQL:
+INSERT INTO t (c) VALUES ({name:String});

--- a/parser/testdata/dml/insert_select_without_from.sql
+++ b/parser/testdata/dml/insert_select_without_from.sql
@@ -1,0 +1,2 @@
+INSERT INTO t (c) SELECT 1 WHERE 1 = 1;
+

--- a/parser/testdata/dml/insert_with_keyword_placeholder.sql
+++ b/parser/testdata/dml/insert_with_keyword_placeholder.sql
@@ -1,0 +1,2 @@
+INSERT INTO t (c) VALUES ({name :String});
+

--- a/parser/testdata/dml/output/insert_select_without_from.sql.golden.json
+++ b/parser/testdata/dml/output/insert_select_without_from.sql.golden.json
@@ -1,0 +1,87 @@
+[
+  {
+    "InsertPos": 0,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": null,
+      "Table": {
+        "Name": "t",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 13
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 14,
+      "RightParenPos": 16,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "c",
+            "QuoteType": 1,
+            "NamePos": 15,
+            "NameEnd": 16
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": null,
+    "SelectExpr": {
+      "SelectPos": 18,
+      "StatementEnd": 38,
+      "With": null,
+      "Top": null,
+      "HasDistinct": false,
+      "DistinctOn": null,
+      "SelectItems": [
+        {
+          "Expr": {
+            "NumPos": 25,
+            "NumEnd": 26,
+            "Literal": "1",
+            "Base": 10
+          },
+          "Modifiers": [],
+          "Alias": null
+        }
+      ],
+      "From": null,
+      "ArrayJoin": null,
+      "Window": null,
+      "Prewhere": null,
+      "Where": {
+        "WherePos": 27,
+        "Expr": {
+          "LeftExpr": {
+            "NumPos": 33,
+            "NumEnd": 34,
+            "Literal": "1",
+            "Base": 10
+          },
+          "Operation": "=",
+          "RightExpr": {
+            "NumPos": 37,
+            "NumEnd": 38,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        }
+      },
+      "GroupBy": null,
+      "WithTotal": false,
+      "Having": null,
+      "OrderBy": null,
+      "LimitBy": null,
+      "Limit": null,
+      "Settings": null,
+      "Format": null,
+      "UnionAll": null,
+      "UnionDistinct": null,
+      "Except": null
+    }
+  }
+]

--- a/parser/testdata/dml/output/insert_with_keyword_placeholder.sql.golden.json
+++ b/parser/testdata/dml/output/insert_with_keyword_placeholder.sql.golden.json
@@ -1,0 +1,58 @@
+[
+  {
+    "InsertPos": 0,
+    "Format": null,
+    "HasTableKeyword": false,
+    "Table": {
+      "Database": null,
+      "Table": {
+        "Name": "t",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 13
+      }
+    },
+    "ColumnNames": {
+      "LeftParenPos": 14,
+      "RightParenPos": 16,
+      "ColumnNames": [
+        {
+          "Ident": {
+            "Name": "c",
+            "QuoteType": 1,
+            "NamePos": 15,
+            "NameEnd": 16
+          },
+          "DotIdent": null
+        }
+      ]
+    },
+    "Values": [
+      {
+        "LeftParenPos": 25,
+        "RightParenPos": 40,
+        "Values": [
+          {
+            "LeftBracePos": 26,
+            "RightBracePos": 40,
+            "Name": {
+              "Name": "name",
+              "QuoteType": 1,
+              "NamePos": 27,
+              "NameEnd": 31
+            },
+            "Type": {
+              "Name": {
+                "Name": "String",
+                "QuoteType": 1,
+                "NamePos": 33,
+                "NameEnd": 39
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "SelectExpr": null
+  }
+]

--- a/parser/testdata/query/format/select_with_keyword_placeholder.sql
+++ b/parser/testdata/query/format/select_with_keyword_placeholder.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+SELECT {name :String};
+SELECT toString({name :String});
+
+
+
+-- Format SQL:
+SELECT {name: String};
+SELECT toString({name: String});

--- a/parser/testdata/query/format/select_without_from_where.sql
+++ b/parser/testdata/query/format/select_without_from_where.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+SELECT 1 WHERE 1 = 1;
+SELECT {p :UInt8} WHERE {p :UInt8} = 1;
+
+
+
+-- Format SQL:
+SELECT 1 WHERE 1 = 1;
+SELECT {p: UInt8} WHERE {p: UInt8} = 1;

--- a/parser/testdata/query/output/select_with_keyword_placeholder.sql.golden.json
+++ b/parser/testdata/query/output/select_with_keyword_placeholder.sql.golden.json
@@ -1,0 +1,121 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 20,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LBracePos": 7,
+          "RBracePos": 20,
+          "Name": {
+            "Name": "name",
+            "QuoteType": 1,
+            "NamePos": 8,
+            "NameEnd": 12
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 14,
+              "NameEnd": 20
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  },
+  {
+    "SelectPos": 23,
+    "StatementEnd": 53,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": {
+            "Name": "toString",
+            "QuoteType": 1,
+            "NamePos": 30,
+            "NameEnd": 38
+          },
+          "Params": {
+            "LeftParenPos": 38,
+            "RightParenPos": 53,
+            "Items": {
+              "ListPos": 39,
+              "ListEnd": 52,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "LBracePos": 39,
+                    "RBracePos": 52,
+                    "Name": {
+                      "Name": "name",
+                      "QuoteType": 1,
+                      "NamePos": 40,
+                      "NameEnd": 44
+                    },
+                    "Type": {
+                      "Name": {
+                        "Name": "String",
+                        "QuoteType": 1,
+                        "NamePos": 46,
+                        "NameEnd": 52
+                      }
+                    }
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/output/select_without_from_where.sql.golden.json
+++ b/parser/testdata/query/output/select_without_from_where.sql.golden.json
@@ -1,0 +1,136 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 20,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "NumPos": 7,
+          "NumEnd": 8,
+          "Literal": "1",
+          "Base": 10
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 9,
+      "Expr": {
+        "LeftExpr": {
+          "NumPos": 15,
+          "NumEnd": 16,
+          "Literal": "1",
+          "Base": 10
+        },
+        "Operation": "=",
+        "RightExpr": {
+          "NumPos": 19,
+          "NumEnd": 20,
+          "Literal": "1",
+          "Base": 10
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  },
+  {
+    "SelectPos": 22,
+    "StatementEnd": 60,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LBracePos": 29,
+          "RBracePos": 38,
+          "Name": {
+            "Name": "p",
+            "QuoteType": 1,
+            "NamePos": 30,
+            "NameEnd": 31
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt8",
+              "QuoteType": 1,
+              "NamePos": 33,
+              "NameEnd": 38
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 40,
+      "Expr": {
+        "LeftExpr": {
+          "LBracePos": 46,
+          "RBracePos": 55,
+          "Name": {
+            "Name": "p",
+            "QuoteType": 1,
+            "NamePos": 47,
+            "NameEnd": 48
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt8",
+              "QuoteType": 1,
+              "NamePos": 50,
+              "NameEnd": 55
+            }
+          }
+        },
+        "Operation": "=",
+        "RightExpr": {
+          "NumPos": 59,
+          "NumEnd": 60,
+          "Literal": "1",
+          "Base": 10
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_with_keyword_placeholder.sql
+++ b/parser/testdata/query/select_with_keyword_placeholder.sql
@@ -1,0 +1,3 @@
+SELECT {name :String};
+SELECT toString({name :String});
+

--- a/parser/testdata/query/select_without_from_where.sql
+++ b/parser/testdata/query/select_without_from_where.sql
@@ -1,0 +1,3 @@
+SELECT 1 WHERE 1 = 1;
+SELECT {p :UInt8} WHERE {p :UInt8} = 1;
+


### PR DESCRIPTION
Two little issues:

## 1. Lookahead issue with typed placeholders

Before: `SELECT {name :String}` (or `INSERT INTO t (c) VALUES ({name :String})`) failed because `{` was misread as a map literal when `name` was lexed as a keyword (e.g., `NAME`), and map keys must be strings.

Fix: In the `{` lookahead, treat both identifier and keyword tokens as "identifier-like" so we choose the placeholder path. This is safe because `parseIdent` already accepts keywords-as-ident. Placeholders now parse correctly across expressions, functions, and `VALUES`.

## 2. WHERE after SELECT without FROM

Before: `INSERT INTO t (c) SELECT 1 WHERE 1 = 1` (and `SELECT 1 WHERE 1 = 1`) errored because `WHERE` was consumed as a bare alias for the select item when `FROM` was absent.

Fix: When parsing select items, do not treat clause-starting keywords (`FROM`, `WHERE`, `ORDER`, `LIMIT`, `UNION`, ...) as aliases. This preserves `WHERE` (and similar) to parse as clauses in `SELECT ... WHERE ...` even without `FROM`, including inside `INSERT ... SELECT ...`.