### PR TITLE
parser: support ALTER TABLE DELETE/UPDATE mutations

### DIFF
--- a/parser/ast_visitor.go
+++ b/parser/ast_visitor.go
@@ -32,6 +32,9 @@ type ASTVisitor interface {
 	VisitAlterTableModifySetting(expr *AlterTableModifySetting) error
 	VisitAlterTableResetSetting(expr *AlterTableResetSetting) error
 	VisitAlterTableReplacePartition(expr *AlterTableReplacePartition) error
+	VisitAlterTableDelete(expr *AlterTableDelete) error
+	VisitAlterTableUpdate(expr *AlterTableUpdate) error
+	VisitUpdateAssignment(expr *UpdateAssignment) error
 	VisitRemovePropertyType(expr *RemovePropertyType) error
 	VisitTableIndex(expr *TableIndex) error
 	VisitIdent(expr *Ident) error
@@ -414,6 +417,27 @@ func (v *DefaultASTVisitor) VisitAlterTableResetSetting(expr *AlterTableResetSet
 }
 
 func (v *DefaultASTVisitor) VisitAlterTableReplacePartition(expr *AlterTableReplacePartition) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitAlterTableDelete(expr *AlterTableDelete) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitAlterTableUpdate(expr *AlterTableUpdate) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitUpdateAssignment(expr *UpdateAssignment) error {
 	if v.Visit != nil {
 		return v.Visit(expr)
 	}

--- a/parser/testdata/ddl/alter_table_delete.sql
+++ b/parser/testdata/ddl/alter_table_delete.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test.events DELETE WHERE created_at < '2023-01-01';

--- a/parser/testdata/ddl/alter_table_delete_with_cluster.sql
+++ b/parser/testdata/ddl/alter_table_delete_with_cluster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test.events ON CLUSTER 'default_cluster' DELETE WHERE id = 123 AND status = 'deleted';

--- a/parser/testdata/ddl/alter_table_update.sql
+++ b/parser/testdata/ddl/alter_table_update.sql
@@ -1,0 +1,1 @@
+ALTER TABLE test.users UPDATE status = 'active', updated_at = now() WHERE status = 'pending';

--- a/parser/testdata/ddl/alter_table_update_with_cluster.sql
+++ b/parser/testdata/ddl/alter_table_update_with_cluster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE db.table ON CLUSTER cluster1 UPDATE column1 = column1 + 1 WHERE id > 100;

--- a/parser/testdata/ddl/format/alter_table_delete.sql
+++ b/parser/testdata/ddl/format/alter_table_delete.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+ALTER TABLE test.events DELETE WHERE created_at < '2023-01-01';
+
+
+-- Format SQL:
+ALTER TABLE test.events DELETE WHERE created_at < '2023-01-01';

--- a/parser/testdata/ddl/format/alter_table_delete_with_cluster.sql
+++ b/parser/testdata/ddl/format/alter_table_delete_with_cluster.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+ALTER TABLE test.events ON CLUSTER 'default_cluster' DELETE WHERE id = 123 AND status = 'deleted';
+
+
+-- Format SQL:
+ALTER TABLE test.events ON CLUSTER 'default_cluster' DELETE WHERE id = 123 AND status = 'deleted';

--- a/parser/testdata/ddl/format/alter_table_update.sql
+++ b/parser/testdata/ddl/format/alter_table_update.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+ALTER TABLE test.users UPDATE status = 'active', updated_at = now() WHERE status = 'pending';
+
+
+-- Format SQL:
+ALTER TABLE test.users UPDATE status = 'active', updated_at = now() WHERE status = 'pending';

--- a/parser/testdata/ddl/format/alter_table_update_with_cluster.sql
+++ b/parser/testdata/ddl/format/alter_table_update_with_cluster.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+ALTER TABLE db.table ON CLUSTER cluster1 UPDATE column1 = column1 + 1 WHERE id > 100;
+
+
+-- Format SQL:
+ALTER TABLE db.table ON CLUSTER cluster1 UPDATE column1 = column1 + 1 WHERE id > 100;

--- a/parser/testdata/ddl/output/alter_table_delete.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_delete.sql.golden.json
@@ -1,0 +1,43 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 61,
+    "TableIdentifier": {
+      "Database": {
+        "Name": "test",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 16
+      },
+      "Table": {
+        "Name": "events",
+        "QuoteType": 1,
+        "NamePos": 17,
+        "NameEnd": 23
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "DeletePos": 24,
+        "StatementEnd": 61,
+        "WhereClause": {
+          "LeftExpr": {
+            "Name": "created_at",
+            "QuoteType": 1,
+            "NamePos": 37,
+            "NameEnd": 47
+          },
+          "Operation": "\u003c",
+          "RightExpr": {
+            "LiteralPos": 51,
+            "LiteralEnd": 61,
+            "Literal": "2023-01-01"
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        }
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/alter_table_delete_with_cluster.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_delete_with_cluster.sql.golden.json
@@ -1,0 +1,72 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 96,
+    "TableIdentifier": {
+      "Database": {
+        "Name": "test",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 16
+      },
+      "Table": {
+        "Name": "events",
+        "QuoteType": 1,
+        "NamePos": 17,
+        "NameEnd": 23
+      }
+    },
+    "OnCluster": {
+      "OnPos": 24,
+      "Expr": {
+        "LiteralPos": 36,
+        "LiteralEnd": 51,
+        "Literal": "default_cluster"
+      }
+    },
+    "AlterExprs": [
+      {
+        "DeletePos": 53,
+        "StatementEnd": 96,
+        "WhereClause": {
+          "LeftExpr": {
+            "LeftExpr": {
+              "Name": "id",
+              "QuoteType": 1,
+              "NamePos": 66,
+              "NameEnd": 68
+            },
+            "Operation": "=",
+            "RightExpr": {
+              "NumPos": 71,
+              "NumEnd": 74,
+              "Literal": "123",
+              "Base": 10
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "Operation": "AND",
+          "RightExpr": {
+            "LeftExpr": {
+              "Name": "status",
+              "QuoteType": 1,
+              "NamePos": 79,
+              "NameEnd": 85
+            },
+            "Operation": "=",
+            "RightExpr": {
+              "LiteralPos": 89,
+              "LiteralEnd": 96,
+              "Literal": "deleted"
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        }
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/alter_table_update.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_update.sql.golden.json
@@ -1,0 +1,93 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 91,
+    "TableIdentifier": {
+      "Database": {
+        "Name": "test",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 16
+      },
+      "Table": {
+        "Name": "users",
+        "QuoteType": 1,
+        "NamePos": 17,
+        "NameEnd": 22
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "UpdatePos": 23,
+        "StatementEnd": 91,
+        "Assignments": [
+          {
+            "AssignmentPos": 30,
+            "Column": {
+              "Ident": {
+                "Name": "status",
+                "QuoteType": 1,
+                "NamePos": 30,
+                "NameEnd": 36
+              },
+              "DotIdent": null
+            },
+            "Expr": {
+              "LiteralPos": 40,
+              "LiteralEnd": 46,
+              "Literal": "active"
+            }
+          },
+          {
+            "AssignmentPos": 49,
+            "Column": {
+              "Ident": {
+                "Name": "updated_at",
+                "QuoteType": 1,
+                "NamePos": 49,
+                "NameEnd": 59
+              },
+              "DotIdent": null
+            },
+            "Expr": {
+              "Name": {
+                "Name": "now",
+                "QuoteType": 1,
+                "NamePos": 62,
+                "NameEnd": 65
+              },
+              "Params": {
+                "LeftParenPos": 65,
+                "RightParenPos": 66,
+                "Items": {
+                  "ListPos": 66,
+                  "ListEnd": 66,
+                  "HasDistinct": false,
+                  "Items": []
+                },
+                "ColumnArgList": null
+              }
+            }
+          }
+        ],
+        "WhereClause": {
+          "LeftExpr": {
+            "Name": "status",
+            "QuoteType": 1,
+            "NamePos": 74,
+            "NameEnd": 80
+          },
+          "Operation": "=",
+          "RightExpr": {
+            "LiteralPos": 84,
+            "LiteralEnd": 91,
+            "Literal": "pending"
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        }
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/alter_table_update_with_cluster.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_update_with_cluster.sql.golden.json
@@ -1,0 +1,83 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 84,
+    "TableIdentifier": {
+      "Database": {
+        "Name": "db",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 14
+      },
+      "Table": {
+        "Name": "table",
+        "QuoteType": 1,
+        "NamePos": 15,
+        "NameEnd": 20
+      }
+    },
+    "OnCluster": {
+      "OnPos": 21,
+      "Expr": {
+        "Name": "cluster1",
+        "QuoteType": 1,
+        "NamePos": 32,
+        "NameEnd": 40
+      }
+    },
+    "AlterExprs": [
+      {
+        "UpdatePos": 41,
+        "StatementEnd": 84,
+        "Assignments": [
+          {
+            "AssignmentPos": 48,
+            "Column": {
+              "Ident": {
+                "Name": "column1",
+                "QuoteType": 1,
+                "NamePos": 48,
+                "NameEnd": 55
+              },
+              "DotIdent": null
+            },
+            "Expr": {
+              "LeftExpr": {
+                "Name": "column1",
+                "QuoteType": 1,
+                "NamePos": 58,
+                "NameEnd": 65
+              },
+              "Operation": "+",
+              "RightExpr": {
+                "NumPos": 68,
+                "NumEnd": 69,
+                "Literal": "1",
+                "Base": 10
+              },
+              "HasGlobal": false,
+              "HasNot": false
+            }
+          }
+        ],
+        "WhereClause": {
+          "LeftExpr": {
+            "Name": "id",
+            "QuoteType": 1,
+            "NamePos": 76,
+            "NameEnd": 78
+          },
+          "Operation": "\u003e",
+          "RightExpr": {
+            "NumPos": 81,
+            "NumEnd": 84,
+            "Literal": "100",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        }
+      }
+    ]
+  }
+]

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -885,6 +885,26 @@ func Walk(node Expr, fn WalkFunc) bool {
 		if !Walk(n.Table, fn) {
 			return false
 		}
+	case *AlterTableDelete:
+		if !Walk(n.WhereClause, fn) {
+			return false
+		}
+	case *AlterTableUpdate:
+		for _, assignment := range n.Assignments {
+			if !Walk(assignment, fn) {
+				return false
+			}
+		}
+		if !Walk(n.WhereClause, fn) {
+			return false
+		}
+	case *UpdateAssignment:
+		if !Walk(n.Column, fn) {
+			return false
+		}
+		if !Walk(n.Expr, fn) {
+			return false
+		}
 	case *AlterRole:
 		for _, pair := range n.RoleRenamePairs {
 			if !Walk(pair, fn) {


### PR DESCRIPTION
Support the ClickHouse "heavyweight" DELETE and UPDATE table mutations.

- `ALTER TABLE ... DELETE WHERE <condition>`
- `ALTER TABLE ... UPDATE col = expr [, ...] WHERE <condition>`

https://clickhouse.com/docs/sql-reference/statements/alter/delete
https://clickhouse.com/docs/sql-reference/statements/alter/update