### PR TITLE
parser: QBit data type support via simplified identifier handling

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -874,11 +874,13 @@ func (p *Parser) parseColumnType(_ Pos) (ColumnType, error) { // nolint:funlen
 	if p.tryConsumeTokenKind(TokenKindLParen) != nil {
 		switch {
 		case p.matchTokenKind(TokenKindIdent):
-			switch ident.Name {
-			case "Nested":
+			switch {
+			case strings.EqualFold(ident.Name, "Nested"):
 				return p.parseNestedType(ident, p.Pos())
-			case "JSON":
+			case strings.EqualFold(ident.Name, "JSON"):
 				return p.parseJSONType(ident, p.Pos())
+			case strings.EqualFold(ident.Name, "QBit"):
+				return p.parseColumnTypeWithParams(ident, p.Pos())
 			default:
 				return p.parseComplexType(ident, p.Pos())
 			}

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -315,11 +315,13 @@ func (p *Parser) parseLiteral(pos Pos) (Literal, error) {
 		return p.parseNumber(pos)
 	case p.matchTokenKind(TokenKindString):
 		return p.parseString(pos)
+	case p.matchTokenKind(TokenKindIdent):
+		return p.parseIdent()
 	case p.matchKeyword(KeywordNull):
 		// accept the NULL keyword
 		return &NullLiteral{NullPos: pos}, nil
 	default:
-		return nil, fmt.Errorf("expected <int>, <string> or keyword <NULL>, but got %q", p.lastTokenKind())
+		return nil, fmt.Errorf("expected <int>, <string>, <ident> or keyword <NULL>, but got %q", p.lastTokenKind())
 	}
 }
 

--- a/parser/testdata/ddl/create_table_with_qbit.sql
+++ b/parser/testdata/ddl/create_table_with_qbit.sql
@@ -1,0 +1,4 @@
+CREATE TABLE test.qbit_example (
+    id UInt32,
+    vec QBit(Float32, 8)
+) ENGINE = Memory;

--- a/parser/testdata/ddl/format/create_table_with_qbit.sql
+++ b/parser/testdata/ddl/format/create_table_with_qbit.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+CREATE TABLE test.qbit_example (
+    id UInt32,
+    vec QBit(Float32, 8)
+) ENGINE = Memory;
+
+
+-- Format SQL:
+CREATE TABLE test.qbit_example (id UInt32, vec QBit(Float32, 8)) ENGINE = Memory;

--- a/parser/testdata/ddl/output/create_table_with_qbit.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_qbit.sql.golden.json
@@ -1,0 +1,123 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 90,
+    "OrReplace": false,
+    "Name": {
+      "Database": {
+        "Name": "test",
+        "QuoteType": 1,
+        "NamePos": 13,
+        "NameEnd": 17
+      },
+      "Table": {
+        "Name": "qbit_example",
+        "QuoteType": 1,
+        "NamePos": 18,
+        "NameEnd": 30
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "TableSchema": {
+      "SchemaPos": 31,
+      "SchemaEnd": 73,
+      "Columns": [
+        {
+          "NamePos": 37,
+          "ColumnEnd": 46,
+          "Name": {
+            "Ident": {
+              "Name": "id",
+              "QuoteType": 1,
+              "NamePos": 37,
+              "NameEnd": 39
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt32",
+              "QuoteType": 1,
+              "NamePos": 40,
+              "NameEnd": 46
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 52,
+          "ColumnEnd": 71,
+          "Name": {
+            "Ident": {
+              "Name": "vec",
+              "QuoteType": 1,
+              "NamePos": 52,
+              "NameEnd": 55
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 61,
+            "RightParenPos": 71,
+            "Name": {
+              "Name": "QBit",
+              "QuoteType": 1,
+              "NamePos": 56,
+              "NameEnd": 60
+            },
+            "Params": [
+              {
+                "Name": "Float32",
+                "QuoteType": 1,
+                "NamePos": 61,
+                "NameEnd": 68
+              },
+              {
+                "NumPos": 70,
+                "NumEnd": 71,
+                "Literal": "8",
+                "Base": 10
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        }
+      ],
+      "AliasTable": null,
+      "TableFunction": null
+    },
+    "Engine": {
+      "EnginePos": 75,
+      "EngineEnd": 90,
+      "Name": "Memory",
+      "Params": null,
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": null,
+      "OrderBy": null
+    },
+    "SubQuery": null,
+    "HasTemporary": false,
+    "Comment": null
+  }
+]


### PR DESCRIPTION
Updates `parseLiteral()` to handle identifiers like Float32 (previously only handled literals) and return `*Ident` directly. Remove unnecessary `parseTypeParameter()` wrapper; `parseLiteral` just needed a new case to handle `TokenKindIdent` which is now possible.

This allows us to add `QBit` case to the column type parser to support it in ClickHouse 25.10: https://clickhouse.com/docs/sql-reference/data-types/qbit