### PR TITLE
Fix nil pointer for replicated database engine

### DIFF
--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -100,7 +100,7 @@ func (p *Parser) parseCreateDatabase(pos Pos) (*CreateDatabase, error) {
 		return nil, err
 	}
 	if engineExpr != nil {
-		StatementEnd = onCluster.End()
+		StatementEnd = engineExpr.End()
 	}
 	commentExpr, err := p.tryParseComment()
 	if err != nil {

--- a/parser/testdata/ddl/create_database_replicated.sql
+++ b/parser/testdata/ddl/create_database_replicated.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS `test` ENGINE=Replicated('/root/test_local', 'shard', 'replica');

--- a/parser/testdata/ddl/format/create_database_replicated.sql
+++ b/parser/testdata/ddl/format/create_database_replicated.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+CREATE DATABASE IF NOT EXISTS `test` ENGINE=Replicated('/root/test_local', 'shard', 'replica');
+
+
+-- Format SQL:
+CREATE DATABASE IF NOT EXISTS `test`  ENGINE = Replicated('/root/test_local', 'shard', 'replica');

--- a/parser/testdata/ddl/output/create_database_replicated.sql.golden.json
+++ b/parser/testdata/ddl/output/create_database_replicated.sql.golden.json
@@ -1,0 +1,62 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 54,
+    "Name": {
+      "Name": "test",
+      "QuoteType": 3,
+      "NamePos": 31,
+      "NameEnd": 35
+    },
+    "IfNotExists": true,
+    "OnCluster": null,
+    "Engine": {
+      "EnginePos": 37,
+      "EngineEnd": 54,
+      "Name": "Replicated",
+      "Params": {
+        "LeftParenPos": 54,
+        "RightParenPos": 93,
+        "Items": {
+          "ListPos": 56,
+          "ListEnd": 92,
+          "HasDistinct": false,
+          "Items": [
+            {
+              "Expr": {
+                "LiteralPos": 56,
+                "LiteralEnd": 72,
+                "Literal": "/root/test_local"
+              },
+              "Alias": null
+            },
+            {
+              "Expr": {
+                "LiteralPos": 76,
+                "LiteralEnd": 81,
+                "Literal": "shard"
+              },
+              "Alias": null
+            },
+            {
+              "Expr": {
+                "LiteralPos": 85,
+                "LiteralEnd": 92,
+                "Literal": "replica"
+              },
+              "Alias": null
+            }
+          ]
+        },
+        "ColumnArgList": null
+      },
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": null,
+      "OrderBy": null
+    },
+    "Comment": null
+  }
+]


### PR DESCRIPTION
There is a bug in the `parseCreateDatabase` which results in nil pointer when setting the engine for a replicated database, because it sets `StatementEnd` to `onCluster.End()` after checking if `engineExpr` is nil.
https://github.com/AfterShip/clickhouse-sql-parser/blob/c9e8bb49915ee6fcdee7589ba78447b09a46c40e/parser/parser_table.go#L102-L104

In this PR this is fixed and test case for replicated database is added.