### PR TITLE
bug: fix a crash with an invalid query following MODIFY QUERY

### DIFF
--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -648,7 +648,10 @@ func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
 		}, nil
 	case p.matchKeyword(KeywordQuery):
 		_ = p.lexer.consumeToken()
-		selectQuery, _ := p.parseSelectQuery(pos)
+		selectQuery, err := p.parseSelectQuery(pos)
+		if err != nil {
+			return nil, err
+		}
 		return &AlterTableModifyQuery{
 			ModifyPos:    pos,
 			StatementEnd: selectQuery.End(),

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -140,6 +140,7 @@ func TestParser_InvalidSyntax(t *testing.T) {
 		"SELECT n FROM t ORDER BY n WITH FILL STALENESS",                   // STALENESS without value
 		"SELECT n FROM t ORDER BY n WITH FILL INTERPOLATE (x",              // Missing closing paren
 		"SELECT n FROM t ORDER BY n WITH FILL INTERPOLATE x AS x + 1",      // Missing parens around column list
+		"ALTER TABLE foo_mv MODIFY QUERY AS SELECT * FROM baz",             // MODIFY QUERY followed by an invalid query
 	}
 	for _, sql := range invalidSQLs {
 		parser := NewParser(sql)


### PR DESCRIPTION
ALTER TABLE foo MODIFY QUERY <an invalid query> crashed the parser with a sigsegv due to a missing error check; this commit adds the missing check and a regression test.