### PR TITLE
Fix workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 
 name: CI Actions
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/AfterShip/clickhouse-sql-parser/security/code-scanning/1](https://github.com/AfterShip/clickhouse-sql-parser/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow or for the specific job. Since the job only needs to check out code and push coverage to an external service (via HTTP using the token as a secret), it only requires read access to repository contents and no write permissions.

The best fix without changing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs by default. In `.github/workflows/ci.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI Actions` and the `on:` block. No other changes are required: the steps will continue to run as before, but `GITHUB_TOKEN` will be restricted to read-only access to repository contents, which is sufficient for `actions/checkout@v3` and does not affect sending coverage data to Coveralls because that uses the token only as a generic secret value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
