### PR TITLE
Add support for concat operator

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -25,11 +25,12 @@ const (
 	TokenKindGE           TokenKind = ">="
 	TokenKindQuestionMark TokenKind = "?"
 
-	TokenKindPlus  TokenKind = "+"
-	TokenKindMinus TokenKind = "-"
-	TokenKindMul   TokenKind = "*"
-	TokenKindDiv   TokenKind = "/"
-	TokenKindMod   TokenKind = "%"
+	TokenKindPlus   TokenKind = "+"
+	TokenKindMinus  TokenKind = "-"
+	TokenKindMul    TokenKind = "*"
+	TokenKindDiv    TokenKind = "/"
+	TokenKindMod    TokenKind = "%"
+	TokenKindConcat TokenKind = "||"
 
 	TokenKindArrow TokenKind = "->"
 	TokenKindDash  TokenKind = "::"

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -16,6 +16,7 @@ const (
 	PrecedenceCompare
 	PrecedenceBetweenLike
 	precedenceIn
+	PrecedenceConcat
 	PrecedenceAddSub
 	PrecedenceMulDivMod
 	PrecedenceBracket
@@ -49,6 +50,8 @@ func (p *Parser) getNextPrecedence() int {
 		p.matchTokenKind(TokenKindGE), p.matchTokenKind(TokenKindGT), p.matchTokenKind(TokenKindDoubleEQ),
 		p.matchTokenKind(TokenKindNE), p.matchTokenKind("<>"):
 		return PrecedenceCompare
+	case p.matchTokenKind(TokenKindConcat):
+		return PrecedenceConcat
 	case p.matchTokenKind(TokenKindPlus), p.matchTokenKind(TokenKindMinus):
 		return PrecedenceAddSub
 	case p.matchTokenKind(TokenKindMul), p.matchTokenKind(TokenKindDiv), p.matchTokenKind(TokenKindMod):
@@ -80,7 +83,7 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		p.matchTokenKind(TokenKindGE), p.matchTokenKind(TokenKindGT),
 		p.matchTokenKind(TokenKindNE), p.matchTokenKind("<>"),
 		p.matchTokenKind(TokenKindMinus), p.matchTokenKind(TokenKindPlus), p.matchTokenKind(TokenKindMul),
-		p.matchTokenKind(TokenKindDiv), p.matchTokenKind(TokenKindMod),
+		p.matchTokenKind(TokenKindDiv), p.matchTokenKind(TokenKindMod), p.matchTokenKind(TokenKindConcat),
 		p.matchKeyword(KeywordIn), p.matchKeyword(KeywordLike),
 		p.matchKeyword(KeywordIlike), p.matchKeyword(KeywordAnd), p.matchKeyword(KeywordOr),
 		p.matchTokenKind(TokenKindArrow), p.matchTokenKind(TokenKindDoubleEQ):

--- a/parser/testdata/query/format/select_concat_expr.sql
+++ b/parser/testdata/query/format/select_concat_expr.sql
@@ -1,0 +1,10 @@
+-- Origin SQL:
+SELECT 'a' || 'b';
+SELECT 'a' || 'b' || 'c';
+SELECT 'a' || 'b' || 'c' + 5;
+
+
+-- Format SQL:
+SELECT 'a' || 'b';
+SELECT 'a' || 'b' || 'c';
+SELECT 'a' || 'b' || 'c' + 5;

--- a/parser/testdata/query/output/select_concat_expr.sql.golden.json
+++ b/parser/testdata/query/output/select_concat_expr.sql.golden.json
@@ -1,0 +1,168 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 16,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LiteralPos": 8,
+            "LiteralEnd": 9,
+            "Literal": "a"
+          },
+          "Operation": "||",
+          "RightExpr": {
+            "LiteralPos": 15,
+            "LiteralEnd": 16,
+            "Literal": "b"
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  },
+  {
+    "SelectPos": 19,
+    "StatementEnd": 42,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftExpr": {
+              "LiteralPos": 27,
+              "LiteralEnd": 28,
+              "Literal": "a"
+            },
+            "Operation": "||",
+            "RightExpr": {
+              "LiteralPos": 34,
+              "LiteralEnd": 35,
+              "Literal": "b"
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "Operation": "||",
+          "RightExpr": {
+            "LiteralPos": 41,
+            "LiteralEnd": 42,
+            "Literal": "c"
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  },
+  {
+    "SelectPos": 45,
+    "StatementEnd": 73,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftExpr": {
+              "LiteralPos": 53,
+              "LiteralEnd": 54,
+              "Literal": "a"
+            },
+            "Operation": "||",
+            "RightExpr": {
+              "LiteralPos": 60,
+              "LiteralEnd": 61,
+              "Literal": "b"
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "Operation": "||",
+          "RightExpr": {
+            "LeftExpr": {
+              "LiteralPos": 67,
+              "LiteralEnd": 68,
+              "Literal": "c"
+            },
+            "Operation": "+",
+            "RightExpr": {
+              "NumPos": 72,
+              "NumEnd": 73,
+              "Literal": "5",
+              "Base": 10
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "ArrayJoin": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_concat_expr.sql
+++ b/parser/testdata/query/select_concat_expr.sql
@@ -1,0 +1,3 @@
+SELECT 'a' || 'b';
+SELECT 'a' || 'b' || 'c';
+SELECT 'a' || 'b' || 'c' + 5;


### PR DESCRIPTION
This adds support for the concat operator `||`. It has lower priority than the `+`/`-` operators.

From https://github.com/ClickHouse/ClickHouse/blob/c8a381a513631cfe1c6b6ebd9702f655c1da45cd/src/Parsers/ExpressionListParsers.cpp#L2501
