### PR TITLE
Add support for CREATE NAMED COLLECTION statements (#235)

### DIFF
--- a/parser/ast_visitor.go
+++ b/parser/ast_visitor.go
@@ -118,6 +118,8 @@ type ASTVisitor interface {
 	VisitTopExpr(expr *TopClause) error
 	VisitCreateLiveView(expr *CreateLiveView) error
 	VisitCreateDictionary(expr *CreateDictionary) error
+	VisitCreateNamedCollection(expr *CreateNamedCollection) error
+	VisitNamedCollectionParam(expr *NamedCollectionParam) error
 	VisitDictionarySchemaClause(expr *DictionarySchemaClause) error
 	VisitDictionaryAttribute(expr *DictionaryAttribute) error
 	VisitDictionaryEngineClause(expr *DictionaryEngineClause) error
@@ -1025,6 +1027,20 @@ func (v *DefaultASTVisitor) VisitCreateLiveView(expr *CreateLiveView) error {
 }
 
 func (v *DefaultASTVisitor) VisitCreateDictionary(expr *CreateDictionary) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitCreateNamedCollection(expr *CreateNamedCollection) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitNamedCollectionParam(expr *NamedCollectionParam) error {
 	if v.Visit != nil {
 		return v.Visit(expr)
 	}

--- a/parser/keyword.go
+++ b/parser/keyword.go
@@ -31,6 +31,7 @@ const (
 	KeywordCluster      = "CLUSTER"
 	KeywordCodec        = "CODEC"
 	KeywordCollate      = "COLLATE"
+	KeywordCollection   = "COLLECTION"
 	KeywordColumn       = "COLUMN"
 	KeywordColumns      = "COLUMNS"
 	KeywordComment      = "COMMENT"
@@ -145,6 +146,7 @@ const (
 	KeywordMoves        = "MOVES"
 	KeywordMutation     = "MUTATION"
 	KeywordName         = "NAME"
+	KeywordNamed        = "NAMED"
 	KeywordNan_sql      = "NAN_SQL"
 	KeywordNo           = "NO"
 	KeywordNone         = "NONE"
@@ -157,6 +159,7 @@ const (
 	KeywordOption       = "OPTION"
 	KeywordOr           = "OR"
 	KeywordOrder        = "ORDER"
+	KeywordOverridable  = "OVERRIDABLE"
 	KeywordOuter        = "OUTER"
 	KeywordOutfile      = "OUTFILE"
 	KeywordOver         = "OVER"
@@ -285,6 +288,7 @@ var keywords = NewSet(
 	KeywordCluster,
 	KeywordCodec,
 	KeywordCollate,
+	KeywordCollection,
 	KeywordColumn,
 	KeywordColumns,
 	KeywordComment,
@@ -399,6 +403,7 @@ var keywords = NewSet(
 	KeywordMoves,
 	KeywordMutation,
 	KeywordName,
+	KeywordNamed,
 	KeywordNan_sql,
 	KeywordNo,
 	KeywordNone,
@@ -412,6 +417,7 @@ var keywords = NewSet(
 	KeywordOr,
 	KeywordOrder,
 	KeywordOuter,
+	KeywordOverridable,
 	KeywordOutfile,
 	KeywordOver,
 	KeywordPartition,

--- a/parser/testdata/ddl/create_named_collection_basic.sql
+++ b/parser/testdata/ddl/create_named_collection_basic.sql
@@ -1,0 +1,4 @@
+CREATE NAMED COLLECTION IF NOT EXISTS servercore_s3_config
+AS url = 'http://local-minio:9000/*',
+access_key_id = 'minioadmin',
+secret_access_key = 'minioadmin';

--- a/parser/testdata/ddl/create_named_collection_simple.sql
+++ b/parser/testdata/ddl/create_named_collection_simple.sql
@@ -1,0 +1,3 @@
+CREATE NAMED COLLECTION my_collection
+AS key1 = 'value1',
+key2 = 'value2';

--- a/parser/testdata/ddl/create_named_collection_with_cluster.sql
+++ b/parser/testdata/ddl/create_named_collection_with_cluster.sql
@@ -1,0 +1,4 @@
+CREATE NAMED COLLECTION IF NOT EXISTS my_collection ON CLUSTER my_cluster
+AS key1 = 'value1' OVERRIDABLE,
+key2 = 'value2' NOT OVERRIDABLE,
+key3 = 'value3';

--- a/parser/testdata/ddl/create_named_collection_with_overridable.sql
+++ b/parser/testdata/ddl/create_named_collection_with_overridable.sql
@@ -1,0 +1,4 @@
+CREATE NAMED COLLECTION test_collection
+AS url = 'http://example.com' OVERRIDABLE,
+access_key = 'key123' NOT OVERRIDABLE,
+secret_key = 'secret456';

--- a/parser/testdata/ddl/format/create_named_collection_basic.sql
+++ b/parser/testdata/ddl/format/create_named_collection_basic.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+CREATE NAMED COLLECTION IF NOT EXISTS servercore_s3_config
+AS url = 'http://local-minio:9000/*',
+access_key_id = 'minioadmin',
+secret_access_key = 'minioadmin';
+
+
+-- Format SQL:
+CREATE NAMED COLLECTION IF NOT EXISTS servercore_s3_config AS url = 'http://local-minio:9000/*', access_key_id = 'minioadmin', secret_access_key = 'minioadmin';

--- a/parser/testdata/ddl/format/create_named_collection_simple.sql
+++ b/parser/testdata/ddl/format/create_named_collection_simple.sql
@@ -1,0 +1,8 @@
+-- Origin SQL:
+CREATE NAMED COLLECTION my_collection
+AS key1 = 'value1',
+key2 = 'value2';
+
+
+-- Format SQL:
+CREATE NAMED COLLECTION my_collection AS key1 = 'value1', key2 = 'value2';

--- a/parser/testdata/ddl/format/create_named_collection_with_cluster.sql
+++ b/parser/testdata/ddl/format/create_named_collection_with_cluster.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+CREATE NAMED COLLECTION IF NOT EXISTS my_collection ON CLUSTER my_cluster
+AS key1 = 'value1' OVERRIDABLE,
+key2 = 'value2' NOT OVERRIDABLE,
+key3 = 'value3';
+
+
+-- Format SQL:
+CREATE NAMED COLLECTION IF NOT EXISTS my_collection ON CLUSTER my_cluster AS key1 = 'value1' OVERRIDABLE, key2 = 'value2' NOT OVERRIDABLE, key3 = 'value3';

--- a/parser/testdata/ddl/format/create_named_collection_with_overridable.sql
+++ b/parser/testdata/ddl/format/create_named_collection_with_overridable.sql
@@ -1,0 +1,9 @@
+-- Origin SQL:
+CREATE NAMED COLLECTION test_collection
+AS url = 'http://example.com' OVERRIDABLE,
+access_key = 'key123' NOT OVERRIDABLE,
+secret_key = 'secret456';
+
+
+-- Format SQL:
+CREATE NAMED COLLECTION test_collection AS url = 'http://example.com' OVERRIDABLE, access_key = 'key123' NOT OVERRIDABLE, secret_key = 'secret456';

--- a/parser/testdata/ddl/output/create_named_collection_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_named_collection_basic.sql.golden.json
@@ -1,0 +1,64 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 158,
+    "Name": {
+      "Name": "servercore_s3_config",
+      "QuoteType": 1,
+      "NamePos": 38,
+      "NameEnd": 58
+    },
+    "IfNotExists": true,
+    "OnCluster": null,
+    "Params": [
+      {
+        "ParamPos": 62,
+        "Name": {
+          "Name": "url",
+          "QuoteType": 1,
+          "NamePos": 62,
+          "NameEnd": 65
+        },
+        "Value": {
+          "LiteralPos": 69,
+          "LiteralEnd": 94,
+          "Literal": "http://local-minio:9000/*"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      },
+      {
+        "ParamPos": 97,
+        "Name": {
+          "Name": "access_key_id",
+          "QuoteType": 1,
+          "NamePos": 97,
+          "NameEnd": 110
+        },
+        "Value": {
+          "LiteralPos": 114,
+          "LiteralEnd": 124,
+          "Literal": "minioadmin"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      },
+      {
+        "ParamPos": 127,
+        "Name": {
+          "Name": "secret_access_key",
+          "QuoteType": 1,
+          "NamePos": 127,
+          "NameEnd": 144
+        },
+        "Value": {
+          "LiteralPos": 148,
+          "LiteralEnd": 158,
+          "Literal": "minioadmin"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/create_named_collection_simple.sql.golden.json
+++ b/parser/testdata/ddl/output/create_named_collection_simple.sql.golden.json
@@ -1,0 +1,48 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 72,
+    "Name": {
+      "Name": "my_collection",
+      "QuoteType": 1,
+      "NamePos": 24,
+      "NameEnd": 37
+    },
+    "IfNotExists": false,
+    "OnCluster": null,
+    "Params": [
+      {
+        "ParamPos": 41,
+        "Name": {
+          "Name": "key1",
+          "QuoteType": 1,
+          "NamePos": 41,
+          "NameEnd": 45
+        },
+        "Value": {
+          "LiteralPos": 49,
+          "LiteralEnd": 55,
+          "Literal": "value1"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      },
+      {
+        "ParamPos": 58,
+        "Name": {
+          "Name": "key2",
+          "QuoteType": 1,
+          "NamePos": 58,
+          "NameEnd": 62
+        },
+        "Value": {
+          "LiteralPos": 66,
+          "LiteralEnd": 72,
+          "Literal": "value2"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/create_named_collection_with_cluster.sql.golden.json
+++ b/parser/testdata/ddl/output/create_named_collection_with_cluster.sql.golden.json
@@ -1,0 +1,72 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 153,
+    "Name": {
+      "Name": "my_collection",
+      "QuoteType": 1,
+      "NamePos": 38,
+      "NameEnd": 51
+    },
+    "IfNotExists": true,
+    "OnCluster": {
+      "OnPos": 52,
+      "Expr": {
+        "Name": "my_cluster",
+        "QuoteType": 1,
+        "NamePos": 63,
+        "NameEnd": 73
+      }
+    },
+    "Params": [
+      {
+        "ParamPos": 77,
+        "Name": {
+          "Name": "key1",
+          "QuoteType": 1,
+          "NamePos": 77,
+          "NameEnd": 81
+        },
+        "Value": {
+          "LiteralPos": 85,
+          "LiteralEnd": 91,
+          "Literal": "value1"
+        },
+        "Overridable": true,
+        "NotOverridable": false
+      },
+      {
+        "ParamPos": 106,
+        "Name": {
+          "Name": "key2",
+          "QuoteType": 1,
+          "NamePos": 106,
+          "NameEnd": 110
+        },
+        "Value": {
+          "LiteralPos": 114,
+          "LiteralEnd": 120,
+          "Literal": "value2"
+        },
+        "Overridable": false,
+        "NotOverridable": true
+      },
+      {
+        "ParamPos": 139,
+        "Name": {
+          "Name": "key3",
+          "QuoteType": 1,
+          "NamePos": 139,
+          "NameEnd": 143
+        },
+        "Value": {
+          "LiteralPos": 147,
+          "LiteralEnd": 153,
+          "Literal": "value3"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/create_named_collection_with_overridable.sql.golden.json
+++ b/parser/testdata/ddl/output/create_named_collection_with_overridable.sql.golden.json
@@ -1,0 +1,64 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 145,
+    "Name": {
+      "Name": "test_collection",
+      "QuoteType": 1,
+      "NamePos": 24,
+      "NameEnd": 39
+    },
+    "IfNotExists": false,
+    "OnCluster": null,
+    "Params": [
+      {
+        "ParamPos": 43,
+        "Name": {
+          "Name": "url",
+          "QuoteType": 1,
+          "NamePos": 43,
+          "NameEnd": 46
+        },
+        "Value": {
+          "LiteralPos": 50,
+          "LiteralEnd": 68,
+          "Literal": "http://example.com"
+        },
+        "Overridable": true,
+        "NotOverridable": false
+      },
+      {
+        "ParamPos": 83,
+        "Name": {
+          "Name": "access_key",
+          "QuoteType": 1,
+          "NamePos": 83,
+          "NameEnd": 93
+        },
+        "Value": {
+          "LiteralPos": 97,
+          "LiteralEnd": 103,
+          "Literal": "key123"
+        },
+        "Overridable": false,
+        "NotOverridable": true
+      },
+      {
+        "ParamPos": 122,
+        "Name": {
+          "Name": "secret_key",
+          "QuoteType": 1,
+          "NamePos": 122,
+          "NameEnd": 132
+        },
+        "Value": {
+          "LiteralPos": 136,
+          "LiteralEnd": 145,
+          "Literal": "secret456"
+        },
+        "Overridable": false,
+        "NotOverridable": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This adds support for `CREATE NAMED COLLECTION` statements with the following features:
- `IF NOT EXISTS` clause
- `ON CLUSTER` clause
- Key-value parameters with optional `[NOT] OVERRIDABLE` modifiers

For the detailed syntax, please refer to: https://clickhouse.com/docs/sql-reference/statements/create/named-collection

Related to #235 