### PR TITLE
feat: add COMMENT support to CREATE VIEW parser

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -1452,6 +1452,7 @@ type CreateView struct {
 	UUID         *UUID
 	OnCluster    *ClusterClause
 	TableSchema  *TableSchemaClause
+	Comment      *StringLiteral
 	SubQuery     *SubQuery
 }
 
@@ -1485,6 +1486,11 @@ func (c *CreateView) Accept(visitor ASTVisitor) error {
 	}
 	if c.TableSchema != nil {
 		if err := c.TableSchema.Accept(visitor); err != nil {
+			return err
+		}
+	}
+	if c.Comment != nil {
+		if err := c.Comment.Accept(visitor); err != nil {
 			return err
 		}
 	}

--- a/parser/format.go
+++ b/parser/format.go
@@ -1139,6 +1139,11 @@ func (c *CreateView) FormatSQL(formatter *Formatter) {
 		formatter.WriteExpr(c.TableSchema)
 	}
 
+	if c.Comment != nil {
+		formatter.WriteString(" COMMENT ")
+		formatter.WriteExpr(c.Comment)
+	}
+
 	if c.SubQuery != nil {
 		formatter.WriteString(" AS ")
 		formatter.WriteExpr(c.SubQuery)

--- a/parser/parser_view.go
+++ b/parser/parser_view.go
@@ -240,6 +240,13 @@ func (p *Parser) parseCreateView(pos Pos, orReplace bool) (*CreateView, error) {
 		createView.TableSchema = tableSchema
 	}
 
+	// parse COMMENT clause if exists (before AS SELECT)
+	comment, err := p.tryParseComment()
+	if err != nil {
+		return nil, err
+	}
+	createView.Comment = comment
+
 	if p.tryConsumeKeywords(KeywordAs) {
 		subQuery, err := p.parseSubQuery(p.Pos())
 		if err != nil {

--- a/parser/testdata/ddl/create_view_with_comment.sql
+++ b/parser/testdata/ddl/create_view_with_comment.sql
@@ -1,0 +1,10 @@
+CREATE VIEW IF NOT EXISTS db.my_view
+(
+    `id` Int64,
+    `name` String
+)
+COMMENT '{"blueprint_hash":"abc123"}'
+AS SELECT
+    id,
+    name
+FROM db.my_table;

--- a/parser/testdata/ddl/format/beautify/create_view_with_comment.sql
+++ b/parser/testdata/ddl/format/beautify/create_view_with_comment.sql
@@ -1,0 +1,22 @@
+-- Origin SQL:
+CREATE VIEW IF NOT EXISTS db.my_view
+(
+    `id` Int64,
+    `name` String
+)
+COMMENT '{"blueprint_hash":"abc123"}'
+AS SELECT
+    id,
+    name
+FROM db.my_table;
+
+
+-- Beautify SQL:
+CREATE VIEW IF NOT EXISTS db.my_view (
+  `id` Int64,
+  `name` String
+) COMMENT '{"blueprint_hash":"abc123"}' AS SELECT
+  id,
+  name
+FROM
+  db.my_table;

--- a/parser/testdata/ddl/format/create_view_with_comment.sql
+++ b/parser/testdata/ddl/format/create_view_with_comment.sql
@@ -1,0 +1,15 @@
+-- Origin SQL:
+CREATE VIEW IF NOT EXISTS db.my_view
+(
+    `id` Int64,
+    `name` String
+)
+COMMENT '{"blueprint_hash":"abc123"}'
+AS SELECT
+    id,
+    name
+FROM db.my_table;
+
+
+-- Format SQL:
+CREATE VIEW IF NOT EXISTS db.my_view (`id` Int64, `name` String) COMMENT '{"blueprint_hash":"abc123"}' AS SELECT id, name FROM db.my_table;

--- a/parser/testdata/ddl/output/create_or_replace.sql.golden.json
+++ b/parser/testdata/ddl/output/create_or_replace.sql.golden.json
@@ -409,6 +409,7 @@
       "AliasTable": null,
       "TableFunction": null
     },
+    "Comment": null,
     "SubQuery": {
       "HasParen": false,
       "Select": {

--- a/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_on_cluster_with_uuid.sql.golden.json
@@ -34,6 +34,7 @@
       }
     },
     "TableSchema": null,
+    "Comment": null,
     "SubQuery": {
       "HasParen": true,
       "Select": {

--- a/parser/testdata/ddl/output/create_view_with_comment.sql.golden.json
+++ b/parser/testdata/ddl/output/create_view_with_comment.sql.golden.json
@@ -1,42 +1,47 @@
 [
   {
     "CreatePos": 0,
-    "StatementEnd": 104,
+    "StatementEnd": 156,
     "OrReplace": false,
     "Name": {
-      "Database": null,
+      "Database": {
+        "Name": "db",
+        "QuoteType": 1,
+        "NamePos": 26,
+        "NameEnd": 28
+      },
       "Table": {
         "Name": "my_view",
         "QuoteType": 1,
-        "NamePos": 26,
-        "NameEnd": 33
+        "NamePos": 29,
+        "NameEnd": 36
       }
     },
     "IfNotExists": true,
     "UUID": null,
     "OnCluster": null,
     "TableSchema": {
-      "SchemaPos": 33,
-      "SchemaEnd": 58,
+      "SchemaPos": 37,
+      "SchemaEnd": 73,
       "Columns": [
         {
-          "NamePos": 34,
-          "ColumnEnd": 45,
+          "NamePos": 44,
+          "ColumnEnd": 53,
           "Name": {
             "Ident": {
-              "Name": "col1",
-              "QuoteType": 1,
-              "NamePos": 34,
-              "NameEnd": 38
+              "Name": "id",
+              "QuoteType": 3,
+              "NamePos": 44,
+              "NameEnd": 46
             },
             "DotIdent": null
           },
           "Type": {
             "Name": {
-              "Name": "String",
+              "Name": "Int64",
               "QuoteType": 1,
-              "NamePos": 39,
-              "NameEnd": 45
+              "NamePos": 48,
+              "NameEnd": 53
             }
           },
           "NotNull": null,
@@ -50,14 +55,14 @@
           "CompressionCodec": null
         },
         {
-          "NamePos": 47,
-          "ColumnEnd": 58,
+          "NamePos": 60,
+          "ColumnEnd": 72,
           "Name": {
             "Ident": {
-              "Name": "col2",
-              "QuoteType": 1,
-              "NamePos": 47,
-              "NameEnd": 51
+              "Name": "name",
+              "QuoteType": 3,
+              "NamePos": 60,
+              "NameEnd": 64
             },
             "DotIdent": null
           },
@@ -65,8 +70,8 @@
             "Name": {
               "Name": "String",
               "QuoteType": 1,
-              "NamePos": 52,
-              "NameEnd": 58
+              "NamePos": 66,
+              "NameEnd": 72
             }
           },
           "NotNull": null,
@@ -83,12 +88,16 @@
       "AliasTable": null,
       "TableFunction": null
     },
-    "Comment": null,
+    "Comment": {
+      "LiteralPos": 84,
+      "LiteralEnd": 111,
+      "Literal": "{\"blueprint_hash\":\"abc123\"}"
+    },
     "SubQuery": {
       "HasParen": false,
       "Select": {
-        "SelectPos": 63,
-        "StatementEnd": 104,
+        "SelectPos": 116,
+        "StatementEnd": 156,
         "With": null,
         "Top": null,
         "HasDistinct": false,
@@ -98,8 +107,8 @@
             "Expr": {
               "Name": "id",
               "QuoteType": 1,
-              "NamePos": 74,
-              "NameEnd": 76
+              "NamePos": 127,
+              "NameEnd": 129
             },
             "Modifiers": [],
             "Alias": null
@@ -108,32 +117,37 @@
             "Expr": {
               "Name": "name",
               "QuoteType": 1,
-              "NamePos": 82,
-              "NameEnd": 86
+              "NamePos": 135,
+              "NameEnd": 139
             },
             "Modifiers": [],
             "Alias": null
           }
         ],
         "From": {
-          "FromPos": 87,
+          "FromPos": 140,
           "Expr": {
             "Table": {
-              "TablePos": 96,
-              "TableEnd": 104,
+              "TablePos": 145,
+              "TableEnd": 156,
               "Alias": null,
               "Expr": {
-                "Database": null,
+                "Database": {
+                  "Name": "db",
+                  "QuoteType": 1,
+                  "NamePos": 145,
+                  "NameEnd": 147
+                },
                 "Table": {
                   "Name": "my_table",
                   "QuoteType": 1,
-                  "NamePos": 96,
-                  "NameEnd": 104
+                  "NamePos": 148,
+                  "NameEnd": 156
                 }
               },
               "HasFinal": false
             },
-            "StatementEnd": 104,
+            "StatementEnd": 156,
             "SampleRatio": null,
             "HasFinal": false
           }

--- a/parser/testdata/query/output/create_window_view.sql.golden.json
+++ b/parser/testdata/query/output/create_window_view.sql.golden.json
@@ -16,6 +16,7 @@
     "UUID": null,
     "OnCluster": null,
     "TableSchema": null,
+    "Comment": null,
     "SubQuery": {
       "HasParen": false,
       "Select": {

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -641,6 +641,9 @@ func Walk(node Expr, fn WalkFunc) bool {
 		if !Walk(n.TableSchema, fn) {
 			return false
 		}
+		if !Walk(n.Comment, fn) {
+			return false
+		}
 		if !Walk(n.SubQuery, fn) {
 			return false
 		}


### PR DESCRIPTION
## What

Add COMMENT clause support to CREATE VIEW parsing. ClickHouse supports COMMENT between the schema and AS SELECT:

```sql
CREATE VIEW db.v (columns) COMMENT '{"blueprint_hash":"abc"}' AS SELECT ...
```

The parser previously failed with `expected EOF or ; but got COMMENT`.

## Changes

- `ast.go`: add `Comment *StringLiteral` field to `CreateView` struct
- `parser_view.go`: call `tryParseComment()` in `parseCreateView` before AS
- `format.go`: emit COMMENT in `CreateView.FormatSQL`
- New test case: `create_view_with_comment.sql`
- Updated golden files for existing view tests (new nil Comment field)

## Context

This is needed by [Shopify/clickhouse-platform](https://github.com/Shopify/clickhouse-platform) where the blueprint-manager uses this parser to compare View DDLs. Without COMMENT support, the workaround is `TrimTableComment` which strips the COMMENT line before parsing. That workaround has a bug where it also strips the AS SELECT clause, causing a crash (nil SubQuery).