### PR TITLE
Ensure projections can have either an order by or a group by

### DIFF
--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -166,9 +166,9 @@ func (p *Parser) parseAlterTableAddIndex(pos Pos) (*AlterTableAddIndex, error) {
 	}, nil
 }
 
-func (p *Parser) parseProjectionOrderBy(pos Pos) (*ProjectionOrderByClause, error) {
-	if err := p.expectKeyword(KeywordOrder); err != nil {
-		return nil, err
+func (p *Parser) tryParseProjectionOrderBy(pos Pos) (*ProjectionOrderByClause, error) {
+	if !p.tryConsumeKeywords(KeywordOrder) {
+		return nil, nil // nolint
 	}
 	if err := p.expectKeyword(KeywordBy); err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (p *Parser) parseProjectionSelect(pos Pos) (*ProjectionSelectStmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	orderBy, err := p.parseProjectionOrderBy(p.Pos())
+	orderBy, err := p.tryParseProjectionOrderBy(p.Pos())
 	if err != nil {
 		return nil, err
 	}

--- a/parser/testdata/ddl/alter_table_add_projection_group_by_only.sql
+++ b/parser/testdata/ddl/alter_table_add_projection_group_by_only.sql
@@ -1,0 +1,3 @@
+ALTER TABLE events
+ADD PROJECTION IF NOT EXISTS hourly_stats
+(SELECT toStartOfHour(event_time) AS hour, event_type, count() AS count, uniq(user_id) AS users GROUP BY hour, event_type);

--- a/parser/testdata/ddl/create_table_with_projection_group_by_only.sql
+++ b/parser/testdata/ddl/create_table_with_projection_group_by_only.sql
@@ -1,0 +1,18 @@
+CREATE TABLE events
+(
+    `event_time` DateTime,
+    `event_type` String,
+    `user_id` UInt64,
+    `value` Float64,
+    PROJECTION hourly_aggregates
+    (
+        SELECT
+            toStartOfHour(event_time) AS hour,
+            event_type,
+            count() AS event_count,
+            sum(value) AS total_value
+        GROUP BY hour, event_type
+    )
+)
+ENGINE = MergeTree()
+ORDER BY (event_time, event_type);

--- a/parser/testdata/ddl/format/alter_table_add_projection_group_by_only.sql
+++ b/parser/testdata/ddl/format/alter_table_add_projection_group_by_only.sql
@@ -1,0 +1,8 @@
+-- Origin SQL:
+ALTER TABLE events
+ADD PROJECTION IF NOT EXISTS hourly_stats
+(SELECT toStartOfHour(event_time) AS hour, event_type, count() AS count, uniq(user_id) AS users GROUP BY hour, event_type);
+
+
+-- Format SQL:
+ALTER TABLE events ADD PROJECTION IF NOT EXISTS hourly_stats (SELECT toStartOfHour(event_time) AS hour, event_type, count() AS count, uniq(user_id) AS users GROUP BY hour, event_type);

--- a/parser/testdata/ddl/format/beautify/alter_table_add_projection_group_by_only.sql
+++ b/parser/testdata/ddl/format/beautify/alter_table_add_projection_group_by_only.sql
@@ -1,0 +1,10 @@
+-- Origin SQL:
+ALTER TABLE events
+ADD PROJECTION IF NOT EXISTS hourly_stats
+(SELECT toStartOfHour(event_time) AS hour, event_type, count() AS count, uniq(user_id) AS users GROUP BY hour, event_type);
+
+
+-- Beautify SQL:
+ALTER TABLE events
+ADD PROJECTION IF NOT EXISTS hourly_stats (SELECT toStartOfHour(event_time) AS hour, event_type, count() AS count, uniq(user_id) AS users GROUP BY
+  hour, event_type);

--- a/parser/testdata/ddl/format/beautify/create_table_with_projection_group_by_only.sql
+++ b/parser/testdata/ddl/format/beautify/create_table_with_projection_group_by_only.sql
@@ -1,0 +1,34 @@
+-- Origin SQL:
+CREATE TABLE events
+(
+    `event_time` DateTime,
+    `event_type` String,
+    `user_id` UInt64,
+    `value` Float64,
+    PROJECTION hourly_aggregates
+    (
+        SELECT
+            toStartOfHour(event_time) AS hour,
+            event_type,
+            count() AS event_count,
+            sum(value) AS total_value
+        GROUP BY hour, event_type
+    )
+)
+ENGINE = MergeTree()
+ORDER BY (event_time, event_type);
+
+
+-- Beautify SQL:
+CREATE TABLE events
+(
+  `event_time` DateTime,
+  `event_type` String,
+  `user_id` UInt64,
+  `value` Float64,
+  PROJECTION hourly_aggregates (SELECT toStartOfHour(event_time) AS hour, event_type, count() AS event_count, sum(value) AS total_value GROUP BY
+    hour, event_type)
+)
+ENGINE = MergeTree()
+ORDER BY
+  (event_time, event_type);

--- a/parser/testdata/ddl/format/create_table_with_projection_group_by_only.sql
+++ b/parser/testdata/ddl/format/create_table_with_projection_group_by_only.sql
@@ -1,0 +1,23 @@
+-- Origin SQL:
+CREATE TABLE events
+(
+    `event_time` DateTime,
+    `event_type` String,
+    `user_id` UInt64,
+    `value` Float64,
+    PROJECTION hourly_aggregates
+    (
+        SELECT
+            toStartOfHour(event_time) AS hour,
+            event_type,
+            count() AS event_count,
+            sum(value) AS total_value
+        GROUP BY hour, event_type
+    )
+)
+ENGINE = MergeTree()
+ORDER BY (event_time, event_type);
+
+
+-- Format SQL:
+CREATE TABLE events (`event_time` DateTime, `event_type` String, `user_id` UInt64, `value` Float64, PROJECTION hourly_aggregates (SELECT toStartOfHour(event_time) AS hour, event_type, count() AS event_count, sum(value) AS total_value GROUP BY hour, event_type)) ENGINE = MergeTree() ORDER BY (event_time, event_type);

--- a/parser/testdata/ddl/output/alter_table_add_projection_group_by_only.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_add_projection_group_by_only.sql.golden.json
@@ -1,0 +1,193 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 182,
+    "TableIdentifier": {
+      "Database": null,
+      "Table": {
+        "Name": "events",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 18
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "AddPos": 19,
+        "StatementEnd": 182,
+        "IfNotExists": true,
+        "TableProjection": {
+          "IncludeProjectionKeyword": false,
+          "ProjectionPos": 48,
+          "Identifier": {
+            "Ident": {
+              "Name": "hourly_stats",
+              "QuoteType": 1,
+              "NamePos": 48,
+              "NameEnd": 60
+            },
+            "DotIdent": null
+          },
+          "Select": {
+            "LeftParenPos": 61,
+            "RightParenPos": 182,
+            "With": null,
+            "SelectColumns": {
+              "ListPos": 69,
+              "ListEnd": 156,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "toStartOfHour",
+                      "QuoteType": 1,
+                      "NamePos": 69,
+                      "NameEnd": 82
+                    },
+                    "Params": {
+                      "LeftParenPos": 82,
+                      "RightParenPos": 93,
+                      "Items": {
+                        "ListPos": 83,
+                        "ListEnd": 93,
+                        "HasDistinct": false,
+                        "Items": [
+                          {
+                            "Expr": {
+                              "Name": "event_time",
+                              "QuoteType": 1,
+                              "NamePos": 83,
+                              "NameEnd": 93
+                            },
+                            "Alias": null
+                          }
+                        ]
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "hour",
+                    "QuoteType": 1,
+                    "NamePos": 98,
+                    "NameEnd": 102
+                  }
+                },
+                {
+                  "Expr": {
+                    "Name": "event_type",
+                    "QuoteType": 1,
+                    "NamePos": 104,
+                    "NameEnd": 114
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "count",
+                      "QuoteType": 1,
+                      "NamePos": 116,
+                      "NameEnd": 121
+                    },
+                    "Params": {
+                      "LeftParenPos": 121,
+                      "RightParenPos": 122,
+                      "Items": {
+                        "ListPos": 122,
+                        "ListEnd": 122,
+                        "HasDistinct": false,
+                        "Items": []
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "count",
+                    "QuoteType": 1,
+                    "NamePos": 127,
+                    "NameEnd": 132
+                  }
+                },
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "uniq",
+                      "QuoteType": 1,
+                      "NamePos": 134,
+                      "NameEnd": 138
+                    },
+                    "Params": {
+                      "LeftParenPos": 138,
+                      "RightParenPos": 146,
+                      "Items": {
+                        "ListPos": 139,
+                        "ListEnd": 146,
+                        "HasDistinct": false,
+                        "Items": [
+                          {
+                            "Expr": {
+                              "Name": "user_id",
+                              "QuoteType": 1,
+                              "NamePos": 139,
+                              "NameEnd": 146
+                            },
+                            "Alias": null
+                          }
+                        ]
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "users",
+                    "QuoteType": 1,
+                    "NamePos": 151,
+                    "NameEnd": 156
+                  }
+                }
+              ]
+            },
+            "GroupBy": {
+              "GroupByPos": 157,
+              "GroupByEnd": 182,
+              "AggregateType": "",
+              "Expr": {
+                "ListPos": 166,
+                "ListEnd": 182,
+                "HasDistinct": false,
+                "Items": [
+                  {
+                    "Expr": {
+                      "Name": "hour",
+                      "QuoteType": 1,
+                      "NamePos": 166,
+                      "NameEnd": 170
+                    },
+                    "Alias": null
+                  },
+                  {
+                    "Expr": {
+                      "Name": "event_type",
+                      "QuoteType": 1,
+                      "NamePos": 172,
+                      "NameEnd": 182
+                    },
+                    "Alias": null
+                  }
+                ]
+              },
+              "WithCube": false,
+              "WithRollup": false,
+              "WithTotals": false
+            },
+            "OrderBy": null
+          }
+        },
+        "After": null
+      }
+    ]
+  }
+]

--- a/parser/testdata/ddl/output/create_table_with_projection_group_by_only.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_projection_group_by_only.sql.golden.json
@@ -1,0 +1,384 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 411,
+    "OrReplace": false,
+    "Name": {
+      "Database": null,
+      "Table": {
+        "Name": "events",
+        "QuoteType": 1,
+        "NamePos": 13,
+        "NameEnd": 19
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "TableSchema": {
+      "SchemaPos": 20,
+      "SchemaEnd": 356,
+      "Columns": [
+        {
+          "NamePos": 27,
+          "ColumnEnd": 47,
+          "Name": {
+            "Ident": {
+              "Name": "event_time",
+              "QuoteType": 3,
+              "NamePos": 27,
+              "NameEnd": 37
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "DateTime",
+              "QuoteType": 1,
+              "NamePos": 39,
+              "NameEnd": 47
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 54,
+          "ColumnEnd": 72,
+          "Name": {
+            "Ident": {
+              "Name": "event_type",
+              "QuoteType": 3,
+              "NamePos": 54,
+              "NameEnd": 64
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 66,
+              "NameEnd": 72
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 79,
+          "ColumnEnd": 94,
+          "Name": {
+            "Ident": {
+              "Name": "user_id",
+              "QuoteType": 3,
+              "NamePos": 79,
+              "NameEnd": 86
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt64",
+              "QuoteType": 1,
+              "NamePos": 88,
+              "NameEnd": 94
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 101,
+          "ColumnEnd": 115,
+          "Name": {
+            "Ident": {
+              "Name": "value",
+              "QuoteType": 3,
+              "NamePos": 101,
+              "NameEnd": 106
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "Float64",
+              "QuoteType": 1,
+              "NamePos": 108,
+              "NameEnd": 115
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "IncludeProjectionKeyword": true,
+          "ProjectionPos": 121,
+          "Identifier": {
+            "Ident": {
+              "Name": "hourly_aggregates",
+              "QuoteType": 1,
+              "NamePos": 132,
+              "NameEnd": 149
+            },
+            "DotIdent": null
+          },
+          "Select": {
+            "LeftParenPos": 154,
+            "RightParenPos": 354,
+            "With": null,
+            "SelectColumns": {
+              "ListPos": 183,
+              "ListEnd": 315,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "toStartOfHour",
+                      "QuoteType": 1,
+                      "NamePos": 183,
+                      "NameEnd": 196
+                    },
+                    "Params": {
+                      "LeftParenPos": 196,
+                      "RightParenPos": 207,
+                      "Items": {
+                        "ListPos": 197,
+                        "ListEnd": 207,
+                        "HasDistinct": false,
+                        "Items": [
+                          {
+                            "Expr": {
+                              "Name": "event_time",
+                              "QuoteType": 1,
+                              "NamePos": 197,
+                              "NameEnd": 207
+                            },
+                            "Alias": null
+                          }
+                        ]
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "hour",
+                    "QuoteType": 1,
+                    "NamePos": 212,
+                    "NameEnd": 216
+                  }
+                },
+                {
+                  "Expr": {
+                    "Name": "event_type",
+                    "QuoteType": 1,
+                    "NamePos": 230,
+                    "NameEnd": 240
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "count",
+                      "QuoteType": 1,
+                      "NamePos": 254,
+                      "NameEnd": 259
+                    },
+                    "Params": {
+                      "LeftParenPos": 259,
+                      "RightParenPos": 260,
+                      "Items": {
+                        "ListPos": 260,
+                        "ListEnd": 260,
+                        "HasDistinct": false,
+                        "Items": []
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "event_count",
+                    "QuoteType": 1,
+                    "NamePos": 265,
+                    "NameEnd": 276
+                  }
+                },
+                {
+                  "Expr": {
+                    "Name": {
+                      "Name": "sum",
+                      "QuoteType": 1,
+                      "NamePos": 290,
+                      "NameEnd": 293
+                    },
+                    "Params": {
+                      "LeftParenPos": 293,
+                      "RightParenPos": 299,
+                      "Items": {
+                        "ListPos": 294,
+                        "ListEnd": 299,
+                        "HasDistinct": false,
+                        "Items": [
+                          {
+                            "Expr": {
+                              "Name": "value",
+                              "QuoteType": 1,
+                              "NamePos": 294,
+                              "NameEnd": 299
+                            },
+                            "Alias": null
+                          }
+                        ]
+                      },
+                      "ColumnArgList": null
+                    }
+                  },
+                  "Alias": {
+                    "Name": "total_value",
+                    "QuoteType": 1,
+                    "NamePos": 304,
+                    "NameEnd": 315
+                  }
+                }
+              ]
+            },
+            "GroupBy": {
+              "GroupByPos": 324,
+              "GroupByEnd": 354,
+              "AggregateType": "",
+              "Expr": {
+                "ListPos": 333,
+                "ListEnd": 349,
+                "HasDistinct": false,
+                "Items": [
+                  {
+                    "Expr": {
+                      "Name": "hour",
+                      "QuoteType": 1,
+                      "NamePos": 333,
+                      "NameEnd": 337
+                    },
+                    "Alias": null
+                  },
+                  {
+                    "Expr": {
+                      "Name": "event_type",
+                      "QuoteType": 1,
+                      "NamePos": 339,
+                      "NameEnd": 349
+                    },
+                    "Alias": null
+                  }
+                ]
+              },
+              "WithCube": false,
+              "WithRollup": false,
+              "WithTotals": false
+            },
+            "OrderBy": null
+          }
+        }
+      ],
+      "AliasTable": null,
+      "TableFunction": null
+    },
+    "Engine": {
+      "EnginePos": 358,
+      "EngineEnd": 411,
+      "Name": "MergeTree",
+      "Params": {
+        "LeftParenPos": 376,
+        "RightParenPos": 377,
+        "Items": {
+          "ListPos": 377,
+          "ListEnd": 377,
+          "HasDistinct": false,
+          "Items": []
+        },
+        "ColumnArgList": null
+      },
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": null,
+      "OrderBy": {
+        "OrderPos": 379,
+        "ListEnd": 411,
+        "Items": [
+          {
+            "OrderPos": 379,
+            "Expr": {
+              "LeftParenPos": 388,
+              "RightParenPos": 411,
+              "Items": {
+                "ListPos": 389,
+                "ListEnd": 411,
+                "HasDistinct": false,
+                "Items": [
+                  {
+                    "Expr": {
+                      "Name": "event_time",
+                      "QuoteType": 1,
+                      "NamePos": 389,
+                      "NameEnd": 399
+                    },
+                    "Alias": null
+                  },
+                  {
+                    "Expr": {
+                      "Name": "event_type",
+                      "QuoteType": 1,
+                      "NamePos": 401,
+                      "NameEnd": 411
+                    },
+                    "Alias": null
+                  }
+                ]
+              },
+              "ColumnArgList": null
+            },
+            "Alias": null,
+            "Direction": "",
+            "Fill": null
+          }
+        ],
+        "Interpolate": null
+      }
+    },
+    "SubQuery": null,
+    "TableFunction": null,
+    "HasTemporary": false,
+    "Comment": null
+  }
+]


### PR DESCRIPTION
The existing PROJECTION parsing failed on PROJECTIONS with just a GROUP BY

This worked
```
ALTER TABLE t
ADD PROJECTION p (
    SELECT x ORDER BY x
)
```

But not 

```
ALTER TABLE t
ADD PROJECTION p (
    SELECT x GROUP BY x
)
```

This PR makes both the  GROUP BY  and the ORDER BY optional.

It should also deal with when both are specified even if that will fail at runtime - I suppose that is the correct behaviour for a parser and formatter. 
