### PR TITLE
Add support of REGEXP as binary operator

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -64,7 +64,7 @@ func (p *Parser) getNextPrecedence() int {
 		return PrecedenceDoubleColon
 	case p.matchTokenKind(TokenKindDot):
 		return PrecedenceDot
-	case p.matchKeyword(KeywordBetween), p.matchKeyword(KeywordLike), p.matchKeyword(KeywordIlike):
+	case p.matchKeyword(KeywordBetween), p.matchKeyword(KeywordLike), p.matchKeyword(KeywordIlike), p.matchKeyword(KeywordRegexp):
 		return PrecedenceBetweenLike
 	case p.matchKeyword(KeywordIn):
 		return precedenceIn
@@ -85,7 +85,8 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		p.matchTokenKind(TokenKindMinus), p.matchTokenKind(TokenKindPlus), p.matchTokenKind(TokenKindMul),
 		p.matchTokenKind(TokenKindDiv), p.matchTokenKind(TokenKindMod), p.matchTokenKind(TokenKindConcat),
 		p.matchKeyword(KeywordIn), p.matchKeyword(KeywordLike),
-		p.matchKeyword(KeywordIlike), p.matchKeyword(KeywordAnd), p.matchKeyword(KeywordOr),
+		p.matchKeyword(KeywordIlike), p.matchKeyword(KeywordRegexp),
+		p.matchKeyword(KeywordAnd), p.matchKeyword(KeywordOr),
 		p.matchTokenKind(TokenKindArrow), p.matchTokenKind(TokenKindDoubleEQ):
 		op := p.last().ToString()
 		_ = p.lexer.consumeToken()

--- a/parser/testdata/query/format/beautify/select_case_when_regexp.sql
+++ b/parser/testdata/query/format/beautify/select_case_when_regexp.sql
@@ -1,0 +1,14 @@
+-- Origin SQL:
+SELECT
+    CASE WHEN col REGEXP '^[0-9]+$' THEN toInt32(col) ELSE 0 END AS num_value
+FROM t
+
+
+-- Beautify SQL:
+SELECT
+  CASE
+    WHEN col REGEXP '^[0-9]+$' THEN toInt32(col)
+    ELSE 0
+  END AS num_value
+FROM
+  t;

--- a/parser/testdata/query/format/beautify/select_regexp.sql
+++ b/parser/testdata/query/format/beautify/select_regexp.sql
@@ -1,0 +1,14 @@
+-- Origin SQL:
+SELECT a, b
+FROM t
+WHERE name REGEXP '^foo'
+
+
+-- Beautify SQL:
+SELECT
+  a,
+  b
+FROM
+  t
+WHERE
+  name REGEXP '^foo';

--- a/parser/testdata/query/format/select_case_when_regexp.sql
+++ b/parser/testdata/query/format/select_case_when_regexp.sql
@@ -1,0 +1,8 @@
+-- Origin SQL:
+SELECT
+    CASE WHEN col REGEXP '^[0-9]+$' THEN toInt32(col) ELSE 0 END AS num_value
+FROM t
+
+
+-- Format SQL:
+SELECT CASE WHEN col REGEXP '^[0-9]+$' THEN toInt32(col) ELSE 0 END AS num_value FROM t;

--- a/parser/testdata/query/format/select_regexp.sql
+++ b/parser/testdata/query/format/select_regexp.sql
@@ -1,0 +1,8 @@
+-- Origin SQL:
+SELECT a, b
+FROM t
+WHERE name REGEXP '^foo'
+
+
+-- Format SQL:
+SELECT a, b FROM t WHERE name REGEXP '^foo';

--- a/parser/testdata/query/output/select_case_when_regexp.sql.golden.json
+++ b/parser/testdata/query/output/select_case_when_regexp.sql.golden.json
@@ -1,0 +1,123 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 91,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "CasePos": 11,
+          "EndPos": 0,
+          "Expr": null,
+          "Whens": [
+            {
+              "WhenPos": 16,
+              "ThenPos": 43,
+              "When": {
+                "LeftExpr": {
+                  "Name": "col",
+                  "QuoteType": 1,
+                  "NamePos": 21,
+                  "NameEnd": 24
+                },
+                "Operation": "REGEXP",
+                "RightExpr": {
+                  "LiteralPos": 33,
+                  "LiteralEnd": 41,
+                  "Literal": "^[0-9]+$"
+                },
+                "HasGlobal": false,
+                "HasNot": false
+              },
+              "Then": {
+                "Name": {
+                  "Name": "toInt32",
+                  "QuoteType": 1,
+                  "NamePos": 48,
+                  "NameEnd": 55
+                },
+                "Params": {
+                  "LeftParenPos": 55,
+                  "RightParenPos": 59,
+                  "Items": {
+                    "ListPos": 56,
+                    "ListEnd": 59,
+                    "HasDistinct": false,
+                    "Items": [
+                      {
+                        "Expr": {
+                          "Name": "col",
+                          "QuoteType": 1,
+                          "NamePos": 56,
+                          "NameEnd": 59
+                        },
+                        "Alias": null
+                      }
+                    ]
+                  },
+                  "ColumnArgList": null
+                }
+              },
+              "ElsePos": 0,
+              "Else": null
+            }
+          ],
+          "ElsePos": 61,
+          "Else": {
+            "NumPos": 66,
+            "NumEnd": 67,
+            "Literal": "0",
+            "Base": 10
+          }
+        },
+        "Modifiers": [],
+        "Alias": {
+          "Name": "num_value",
+          "QuoteType": 1,
+          "NamePos": 75,
+          "NameEnd": 84
+        }
+      }
+    ],
+    "From": {
+      "FromPos": 85,
+      "Expr": {
+        "Table": {
+          "TablePos": 90,
+          "TableEnd": 91,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "t",
+              "QuoteType": 1,
+              "NamePos": 90,
+              "NameEnd": 91
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 91,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/output/select_regexp.sql.golden.json
+++ b/parser/testdata/query/output/select_regexp.sql.golden.json
@@ -1,0 +1,87 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 42,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "a",
+          "QuoteType": 1,
+          "NamePos": 7,
+          "NameEnd": 8
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Name": "b",
+          "QuoteType": 1,
+          "NamePos": 10,
+          "NameEnd": 11
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 12,
+      "Expr": {
+        "Table": {
+          "TablePos": 17,
+          "TableEnd": 18,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "t",
+              "QuoteType": 1,
+              "NamePos": 17,
+              "NameEnd": 18
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 18,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 19,
+      "Expr": {
+        "LeftExpr": {
+          "Name": "name",
+          "QuoteType": 1,
+          "NamePos": 25,
+          "NameEnd": 29
+        },
+        "Operation": "REGEXP",
+        "RightExpr": {
+          "LiteralPos": 38,
+          "LiteralEnd": 42,
+          "Literal": "^foo"
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null
+  }
+]

--- a/parser/testdata/query/select_case_when_regexp.sql
+++ b/parser/testdata/query/select_case_when_regexp.sql
@@ -1,0 +1,3 @@
+SELECT
+    CASE WHEN col REGEXP '^[0-9]+$' THEN toInt32(col) ELSE 0 END AS num_value
+FROM t

--- a/parser/testdata/query/select_regexp.sql
+++ b/parser/testdata/query/select_regexp.sql
@@ -1,0 +1,3 @@
+SELECT a, b
+FROM t
+WHERE name REGEXP '^foo'


### PR DESCRIPTION
Recognize `REGEXP` as a binary infix operator alongside `LIKE`/`ILIKE`, so expressions like `CASE WHEN col REGEXP '^[0-9]+$' THEN ... END` parse correctly.