### PR TITLE
Fix should allow column list before ENGINE in CREATE MATERIALIZED VIEW

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -1356,6 +1356,7 @@ type CreateMaterializedView struct {
 	Settings     *SettingsClause
 	HasAppend    bool
 	Engine       *EngineExpr
+	TableSchema  *TableSchemaClause // column list for ENGINE-based MVs (no TO clause)
 	HasEmpty     bool
 	Destination  *DestinationClause
 	SubQuery     *SubQuery
@@ -1407,6 +1408,11 @@ func (c *CreateMaterializedView) Accept(visitor ASTVisitor) error {
 	}
 	if c.Settings != nil {
 		if err := c.Settings.Accept(visitor); err != nil {
+			return err
+		}
+	}
+	if c.TableSchema != nil {
+		if err := c.TableSchema.Accept(visitor); err != nil {
 			return err
 		}
 	}

--- a/parser/format.go
+++ b/parser/format.go
@@ -907,6 +907,10 @@ func (c *CreateMaterializedView) FormatSQL(formatter *Formatter) {
 		formatter.Break()
 		formatter.WriteString("APPEND")
 	}
+	if c.TableSchema != nil {
+		formatter.Break()
+		formatter.WriteExpr(c.TableSchema)
+	}
 	if c.Engine != nil {
 		formatter.Break()
 		formatter.WriteExpr(c.Engine)

--- a/parser/parser_view.go
+++ b/parser/parser_view.go
@@ -66,6 +66,7 @@ func (p *Parser) parseCreateMaterializedView(pos Pos) (*CreateMaterializedView, 
 		}
 		dependsOnTables = append(dependsOnTables, table)
 		for p.matchTokenKind(TokenKindComma) {
+			_ = p.lexer.consumeToken()
 			table, err := p.parseTableIdentifier(p.Pos())
 			if err != nil {
 				return nil, err
@@ -96,6 +97,22 @@ func (p *Parser) parseCreateMaterializedView(pos Pos) (*CreateMaterializedView, 
 			}
 			createMaterializedView.Destination.TableSchema = tableSchema
 		}
+	case p.matchTokenKind(TokenKindLParen):
+		// Column list before ENGINE (e.g. SHOW CREATE TABLE output for RMVs with ENGINE = Memory)
+		tableSchema, err := p.parseTableSchemaClause(p.Pos())
+		if err != nil {
+			return nil, err
+		}
+		createMaterializedView.TableSchema = tableSchema
+		if !p.matchKeyword(KeywordEngine) {
+			return nil, fmt.Errorf("unexpected token: %q, expected ENGINE after column list", p.lastTokenKind())
+		}
+		engineExpr, err := p.parseEngineExpr(p.Pos())
+		if err != nil {
+			return nil, err
+		}
+		createMaterializedView.Engine = engineExpr
+		createMaterializedView.StatementEnd = engineExpr.End()
 	case p.matchKeyword(KeywordEngine):
 		engineExpr, err := p.parseEngineExpr(p.Pos())
 		if err != nil {

--- a/parser/testdata/ddl/create_materialized_view_rmv_depends_on_multi.sql
+++ b/parser/testdata/ddl/create_materialized_view_rmv_depends_on_multi.sql
@@ -1,0 +1,10 @@
+CREATE MATERIALIZED VIEW db1.attrs_rollup_v0
+REFRESH EVERY 5 MINUTE
+DEPENDS ON db1.metadata_mv_v0, db1.metadata_mv_v1
+ENGINE = Memory
+AS SELECT DISTINCT
+    service_name,
+    attr_key,
+    'profiles' AS dataset,
+    'string' AS attr_type
+FROM db1.metadata_v0

--- a/parser/testdata/ddl/create_materialized_view_rmv_engine_with_columns.sql
+++ b/parser/testdata/ddl/create_materialized_view_rmv_engine_with_columns.sql
@@ -1,0 +1,36 @@
+CREATE MATERIALIZED VIEW db1.config_memory_v0
+REFRESH EVERY 1 SECOND
+(
+    `schedule_id` String,
+    `sample_rate` Int8,
+    `start_at` DateTime64(9),
+    `end_at` DateTime64(9),
+    `created_at` DateTime64(9),
+    `created_by` String,
+    `properties` Map(String, String),
+    `cluster_percentage` Float64,
+    `schedule_filters` String
+)
+ENGINE = Memory
+SETTINGS min_rows_to_keep = 250000, max_rows_to_keep = 500000
+DEFINER = default SQL SECURITY DEFINER
+COMMENT 'test comment'
+AS SELECT
+    schedule_id,
+    sample_rate,
+    start_at,
+    end_at,
+    created_at,
+    created_by,
+    properties,
+    cluster_percentage,
+    schedule_filters
+FROM
+(
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY schedule_filters ORDER BY created_at DESC) AS rn
+    FROM db1.config_v0
+    WHERE schedule_filters != '{}'
+)
+WHERE rn = 1

--- a/parser/testdata/ddl/format/beautify/create_materialized_view_rmv_depends_on_multi.sql
+++ b/parser/testdata/ddl/format/beautify/create_materialized_view_rmv_depends_on_multi.sql
@@ -1,0 +1,26 @@
+-- Origin SQL:
+CREATE MATERIALIZED VIEW db1.attrs_rollup_v0
+REFRESH EVERY 5 MINUTE
+DEPENDS ON db1.metadata_mv_v0, db1.metadata_mv_v1
+ENGINE = Memory
+AS SELECT DISTINCT
+    service_name,
+    attr_key,
+    'profiles' AS dataset,
+    'string' AS attr_type
+FROM db1.metadata_v0
+
+
+-- Beautify SQL:
+CREATE MATERIALIZED VIEW db1.attrs_rollup_v0
+REFRESH EVERY 5 MINUTE
+DEPENDS ON db1.metadata_mv_v0, db1.metadata_mv_v1
+ENGINE = Memory
+AS
+  SELECT DISTINCT
+    service_name,
+    attr_key,
+    'profiles' AS dataset,
+    'string' AS attr_type
+  FROM
+    db1.metadata_v0;

--- a/parser/testdata/ddl/format/beautify/create_materialized_view_rmv_engine_with_columns.sql
+++ b/parser/testdata/ddl/format/beautify/create_materialized_view_rmv_engine_with_columns.sql
@@ -1,0 +1,82 @@
+-- Origin SQL:
+CREATE MATERIALIZED VIEW db1.config_memory_v0
+REFRESH EVERY 1 SECOND
+(
+    `schedule_id` String,
+    `sample_rate` Int8,
+    `start_at` DateTime64(9),
+    `end_at` DateTime64(9),
+    `created_at` DateTime64(9),
+    `created_by` String,
+    `properties` Map(String, String),
+    `cluster_percentage` Float64,
+    `schedule_filters` String
+)
+ENGINE = Memory
+SETTINGS min_rows_to_keep = 250000, max_rows_to_keep = 500000
+DEFINER = default SQL SECURITY DEFINER
+COMMENT 'test comment'
+AS SELECT
+    schedule_id,
+    sample_rate,
+    start_at,
+    end_at,
+    created_at,
+    created_by,
+    properties,
+    cluster_percentage,
+    schedule_filters
+FROM
+(
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY schedule_filters ORDER BY created_at DESC) AS rn
+    FROM db1.config_v0
+    WHERE schedule_filters != '{}'
+)
+WHERE rn = 1
+
+
+-- Beautify SQL:
+CREATE MATERIALIZED VIEW db1.config_memory_v0
+REFRESH EVERY 1 SECOND
+(
+  `schedule_id` String,
+  `sample_rate` Int8,
+  `start_at` DateTime64(9),
+  `end_at` DateTime64(9),
+  `created_at` DateTime64(9),
+  `created_by` String,
+  `properties` Map(String, String),
+  `cluster_percentage` Float64,
+  `schedule_filters` String
+)
+ENGINE = Memory
+SETTINGS
+  min_rows_to_keep=250000,
+  max_rows_to_keep=500000
+DEFINER = default
+SQL SECURITY DEFINER
+AS
+  SELECT
+    schedule_id,
+    sample_rate,
+    start_at,
+    end_at,
+    created_at,
+    created_by,
+    properties,
+    cluster_percentage,
+    schedule_filters
+  FROM
+    (SELECT
+      *,
+      row_number() OVER (PARTITION BY schedule_filters ORDER BY
+        created_at DESC) AS rn
+    FROM
+      db1.config_v0
+    WHERE
+      schedule_filters != '{}')
+  WHERE
+    rn = 1
+COMMENT 'test comment';

--- a/parser/testdata/ddl/format/create_materialized_view_rmv_depends_on_multi.sql
+++ b/parser/testdata/ddl/format/create_materialized_view_rmv_depends_on_multi.sql
@@ -1,0 +1,15 @@
+-- Origin SQL:
+CREATE MATERIALIZED VIEW db1.attrs_rollup_v0
+REFRESH EVERY 5 MINUTE
+DEPENDS ON db1.metadata_mv_v0, db1.metadata_mv_v1
+ENGINE = Memory
+AS SELECT DISTINCT
+    service_name,
+    attr_key,
+    'profiles' AS dataset,
+    'string' AS attr_type
+FROM db1.metadata_v0
+
+
+-- Format SQL:
+CREATE MATERIALIZED VIEW db1.attrs_rollup_v0 REFRESH EVERY 5 MINUTE DEPENDS ON db1.metadata_mv_v0, db1.metadata_mv_v1 ENGINE = Memory AS SELECT DISTINCT service_name, attr_key, 'profiles' AS dataset, 'string' AS attr_type FROM db1.metadata_v0;

--- a/parser/testdata/ddl/format/create_materialized_view_rmv_engine_with_columns.sql
+++ b/parser/testdata/ddl/format/create_materialized_view_rmv_engine_with_columns.sql
@@ -1,0 +1,41 @@
+-- Origin SQL:
+CREATE MATERIALIZED VIEW db1.config_memory_v0
+REFRESH EVERY 1 SECOND
+(
+    `schedule_id` String,
+    `sample_rate` Int8,
+    `start_at` DateTime64(9),
+    `end_at` DateTime64(9),
+    `created_at` DateTime64(9),
+    `created_by` String,
+    `properties` Map(String, String),
+    `cluster_percentage` Float64,
+    `schedule_filters` String
+)
+ENGINE = Memory
+SETTINGS min_rows_to_keep = 250000, max_rows_to_keep = 500000
+DEFINER = default SQL SECURITY DEFINER
+COMMENT 'test comment'
+AS SELECT
+    schedule_id,
+    sample_rate,
+    start_at,
+    end_at,
+    created_at,
+    created_by,
+    properties,
+    cluster_percentage,
+    schedule_filters
+FROM
+(
+    SELECT
+        *,
+        row_number() OVER (PARTITION BY schedule_filters ORDER BY created_at DESC) AS rn
+    FROM db1.config_v0
+    WHERE schedule_filters != '{}'
+)
+WHERE rn = 1
+
+
+-- Format SQL:
+CREATE MATERIALIZED VIEW db1.config_memory_v0 REFRESH EVERY 1 SECOND (`schedule_id` String, `sample_rate` Int8, `start_at` DateTime64(9), `end_at` DateTime64(9), `created_at` DateTime64(9), `created_by` String, `properties` Map(String, String), `cluster_percentage` Float64, `schedule_filters` String) ENGINE = Memory SETTINGS min_rows_to_keep=250000, max_rows_to_keep=500000 DEFINER = default SQL SECURITY DEFINER AS SELECT schedule_id, sample_rate, start_at, end_at, created_at, created_by, properties, cluster_percentage, schedule_filters FROM (SELECT *, row_number() OVER (PARTITION BY schedule_filters ORDER BY created_at DESC) AS rn FROM db1.config_v0 WHERE schedule_filters != '{}') WHERE rn = 1 COMMENT 'test comment';

--- a/parser/testdata/ddl/output/bug_001.sql.golden.json
+++ b/parser/testdata/ddl/output/bug_001.sql.golden.json
@@ -31,6 +31,7 @@
     "Settings": null,
     "HasAppend": false,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 89,

--- a/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_basic.sql.golden.json
@@ -31,6 +31,7 @@
     "Settings": null,
     "HasAppend": false,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 78,

--- a/parser/testdata/ddl/output/create_materialized_view_rmv_depends_on_multi.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_rmv_depends_on_multi.sql.golden.json
@@ -1,0 +1,197 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 258,
+    "Name": {
+      "Database": {
+        "Name": "db1",
+        "QuoteType": 1,
+        "NamePos": 25,
+        "NameEnd": 28
+      },
+      "Table": {
+        "Name": "attrs_rollup_v0",
+        "QuoteType": 1,
+        "NamePos": 29,
+        "NameEnd": 44
+      }
+    },
+    "IfNotExists": false,
+    "OnCluster": null,
+    "Refresh": {
+      "RefreshPos": 45,
+      "Frequency": "EVERY",
+      "Interval": {
+        "IntervalPos": 0,
+        "Expr": {
+          "NumPos": 59,
+          "NumEnd": 60,
+          "Literal": "5",
+          "Base": 10
+        },
+        "Unit": {
+          "Name": "MINUTE",
+          "QuoteType": 1,
+          "NamePos": 61,
+          "NameEnd": 67
+        }
+      },
+      "Offset": null
+    },
+    "RandomizeFor": null,
+    "DependsOn": [
+      {
+        "Database": {
+          "Name": "db1",
+          "QuoteType": 1,
+          "NamePos": 79,
+          "NameEnd": 82
+        },
+        "Table": {
+          "Name": "metadata_mv_v0",
+          "QuoteType": 1,
+          "NamePos": 83,
+          "NameEnd": 97
+        }
+      },
+      {
+        "Database": {
+          "Name": "db1",
+          "QuoteType": 1,
+          "NamePos": 99,
+          "NameEnd": 102
+        },
+        "Table": {
+          "Name": "metadata_mv_v1",
+          "QuoteType": 1,
+          "NamePos": 103,
+          "NameEnd": 117
+        }
+      }
+    ],
+    "Settings": null,
+    "HasAppend": false,
+    "Engine": {
+      "EnginePos": 118,
+      "EngineEnd": 133,
+      "Name": "Memory",
+      "Params": null,
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": null,
+      "OrderBy": null
+    },
+    "TableSchema": null,
+    "HasEmpty": false,
+    "Destination": null,
+    "SubQuery": {
+      "HasParen": false,
+      "Select": {
+        "SelectPos": 137,
+        "StatementEnd": 258,
+        "With": null,
+        "Top": null,
+        "HasDistinct": true,
+        "DistinctOn": null,
+        "SelectItems": [
+          {
+            "Expr": {
+              "Name": "service_name",
+              "QuoteType": 1,
+              "NamePos": 157,
+              "NameEnd": 169
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "attr_key",
+              "QuoteType": 1,
+              "NamePos": 175,
+              "NameEnd": 183
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "LiteralPos": 190,
+              "LiteralEnd": 198,
+              "Literal": "profiles"
+            },
+            "Modifiers": [],
+            "Alias": {
+              "Name": "dataset",
+              "QuoteType": 1,
+              "NamePos": 203,
+              "NameEnd": 210
+            }
+          },
+          {
+            "Expr": {
+              "LiteralPos": 217,
+              "LiteralEnd": 223,
+              "Literal": "string"
+            },
+            "Modifiers": [],
+            "Alias": {
+              "Name": "attr_type",
+              "QuoteType": 1,
+              "NamePos": 228,
+              "NameEnd": 237
+            }
+          }
+        ],
+        "From": {
+          "FromPos": 238,
+          "Expr": {
+            "Table": {
+              "TablePos": 243,
+              "TableEnd": 258,
+              "Alias": null,
+              "Expr": {
+                "Database": {
+                  "Name": "db1",
+                  "QuoteType": 1,
+                  "NamePos": 243,
+                  "NameEnd": 246
+                },
+                "Table": {
+                  "Name": "metadata_v0",
+                  "QuoteType": 1,
+                  "NamePos": 247,
+                  "NameEnd": 258
+                }
+              },
+              "HasFinal": false
+            },
+            "StatementEnd": 258,
+            "SampleRatio": null,
+            "HasFinal": false
+          }
+        },
+        "Window": null,
+        "Prewhere": null,
+        "Where": null,
+        "GroupBy": null,
+        "WithTotal": false,
+        "Having": null,
+        "OrderBy": null,
+        "LimitBy": null,
+        "Limit": null,
+        "Settings": null,
+        "Format": null,
+        "UnionAll": null,
+        "UnionDistinct": null,
+        "Except": null
+      }
+    },
+    "Populate": false,
+    "Comment": null,
+    "Definer": null,
+    "SQLSecurity": ""
+  }
+]

--- a/parser/testdata/ddl/output/create_materialized_view_rmv_engine_with_columns.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_rmv_engine_with_columns.sql.golden.json
@@ -1,0 +1,744 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 833,
+    "Name": {
+      "Database": {
+        "Name": "db1",
+        "QuoteType": 1,
+        "NamePos": 25,
+        "NameEnd": 28
+      },
+      "Table": {
+        "Name": "config_memory_v0",
+        "QuoteType": 1,
+        "NamePos": 29,
+        "NameEnd": 45
+      }
+    },
+    "IfNotExists": false,
+    "OnCluster": null,
+    "Refresh": {
+      "RefreshPos": 46,
+      "Frequency": "EVERY",
+      "Interval": {
+        "IntervalPos": 0,
+        "Expr": {
+          "NumPos": 60,
+          "NumEnd": 61,
+          "Literal": "1",
+          "Base": 10
+        },
+        "Unit": {
+          "Name": "SECOND",
+          "QuoteType": 1,
+          "NamePos": 62,
+          "NameEnd": 68
+        }
+      },
+      "Offset": null
+    },
+    "RandomizeFor": null,
+    "DependsOn": null,
+    "Settings": null,
+    "HasAppend": false,
+    "Engine": {
+      "EnginePos": 340,
+      "EngineEnd": 417,
+      "Name": "Memory",
+      "Params": null,
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": {
+        "SettingsPos": 356,
+        "ListEnd": 417,
+        "Items": [
+          {
+            "SettingsPos": 365,
+            "Name": {
+              "Name": "min_rows_to_keep",
+              "QuoteType": 1,
+              "NamePos": 365,
+              "NameEnd": 381
+            },
+            "Expr": {
+              "NumPos": 384,
+              "NumEnd": 390,
+              "Literal": "250000",
+              "Base": 10
+            }
+          },
+          {
+            "SettingsPos": 392,
+            "Name": {
+              "Name": "max_rows_to_keep",
+              "QuoteType": 1,
+              "NamePos": 392,
+              "NameEnd": 408
+            },
+            "Expr": {
+              "NumPos": 411,
+              "NumEnd": 417,
+              "Literal": "500000",
+              "Base": 10
+            }
+          }
+        ]
+      },
+      "OrderBy": null
+    },
+    "TableSchema": {
+      "SchemaPos": 69,
+      "SchemaEnd": 338,
+      "Columns": [
+        {
+          "NamePos": 76,
+          "ColumnEnd": 95,
+          "Name": {
+            "Ident": {
+              "Name": "schedule_id",
+              "QuoteType": 3,
+              "NamePos": 76,
+              "NameEnd": 87
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 89,
+              "NameEnd": 95
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 102,
+          "ColumnEnd": 119,
+          "Name": {
+            "Ident": {
+              "Name": "sample_rate",
+              "QuoteType": 3,
+              "NamePos": 102,
+              "NameEnd": 113
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "Int8",
+              "QuoteType": 1,
+              "NamePos": 115,
+              "NameEnd": 119
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 126,
+          "ColumnEnd": 148,
+          "Name": {
+            "Ident": {
+              "Name": "start_at",
+              "QuoteType": 3,
+              "NamePos": 126,
+              "NameEnd": 134
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 147,
+            "RightParenPos": 148,
+            "Name": {
+              "Name": "DateTime64",
+              "QuoteType": 1,
+              "NamePos": 136,
+              "NameEnd": 146
+            },
+            "Params": [
+              {
+                "NumPos": 147,
+                "NumEnd": 148,
+                "Literal": "9",
+                "Base": 10
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 156,
+          "ColumnEnd": 176,
+          "Name": {
+            "Ident": {
+              "Name": "end_at",
+              "QuoteType": 3,
+              "NamePos": 156,
+              "NameEnd": 162
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 175,
+            "RightParenPos": 176,
+            "Name": {
+              "Name": "DateTime64",
+              "QuoteType": 1,
+              "NamePos": 164,
+              "NameEnd": 174
+            },
+            "Params": [
+              {
+                "NumPos": 175,
+                "NumEnd": 176,
+                "Literal": "9",
+                "Base": 10
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 184,
+          "ColumnEnd": 208,
+          "Name": {
+            "Ident": {
+              "Name": "created_at",
+              "QuoteType": 3,
+              "NamePos": 184,
+              "NameEnd": 194
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 207,
+            "RightParenPos": 208,
+            "Name": {
+              "Name": "DateTime64",
+              "QuoteType": 1,
+              "NamePos": 196,
+              "NameEnd": 206
+            },
+            "Params": [
+              {
+                "NumPos": 207,
+                "NumEnd": 208,
+                "Literal": "9",
+                "Base": 10
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 216,
+          "ColumnEnd": 234,
+          "Name": {
+            "Ident": {
+              "Name": "created_by",
+              "QuoteType": 3,
+              "NamePos": 216,
+              "NameEnd": 226
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 228,
+              "NameEnd": 234
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 241,
+          "ColumnEnd": 271,
+          "Name": {
+            "Ident": {
+              "Name": "properties",
+              "QuoteType": 3,
+              "NamePos": 241,
+              "NameEnd": 251
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 257,
+            "RightParenPos": 271,
+            "Name": {
+              "Name": "Map",
+              "QuoteType": 1,
+              "NamePos": 253,
+              "NameEnd": 256
+            },
+            "Params": [
+              {
+                "Name": {
+                  "Name": "String",
+                  "QuoteType": 1,
+                  "NamePos": 257,
+                  "NameEnd": 263
+                }
+              },
+              {
+                "Name": {
+                  "Name": "String",
+                  "QuoteType": 1,
+                  "NamePos": 265,
+                  "NameEnd": 271
+                }
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 279,
+          "ColumnEnd": 306,
+          "Name": {
+            "Ident": {
+              "Name": "cluster_percentage",
+              "QuoteType": 3,
+              "NamePos": 279,
+              "NameEnd": 297
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "Float64",
+              "QuoteType": 1,
+              "NamePos": 299,
+              "NameEnd": 306
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 313,
+          "ColumnEnd": 337,
+          "Name": {
+            "Ident": {
+              "Name": "schedule_filters",
+              "QuoteType": 3,
+              "NamePos": 313,
+              "NameEnd": 329
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 331,
+              "NameEnd": 337
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        }
+      ],
+      "AliasTable": null,
+      "TableFunction": null
+    },
+    "HasEmpty": false,
+    "Destination": null,
+    "SubQuery": {
+      "HasParen": false,
+      "Select": {
+        "SelectPos": 483,
+        "StatementEnd": 833,
+        "With": null,
+        "Top": null,
+        "HasDistinct": false,
+        "DistinctOn": null,
+        "SelectItems": [
+          {
+            "Expr": {
+              "Name": "schedule_id",
+              "QuoteType": 1,
+              "NamePos": 494,
+              "NameEnd": 505
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "sample_rate",
+              "QuoteType": 1,
+              "NamePos": 511,
+              "NameEnd": 522
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "start_at",
+              "QuoteType": 1,
+              "NamePos": 528,
+              "NameEnd": 536
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "end_at",
+              "QuoteType": 1,
+              "NamePos": 542,
+              "NameEnd": 548
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "created_at",
+              "QuoteType": 1,
+              "NamePos": 554,
+              "NameEnd": 564
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "created_by",
+              "QuoteType": 1,
+              "NamePos": 570,
+              "NameEnd": 580
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "properties",
+              "QuoteType": 1,
+              "NamePos": 586,
+              "NameEnd": 596
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "cluster_percentage",
+              "QuoteType": 1,
+              "NamePos": 602,
+              "NameEnd": 620
+            },
+            "Modifiers": [],
+            "Alias": null
+          },
+          {
+            "Expr": {
+              "Name": "schedule_filters",
+              "QuoteType": 1,
+              "NamePos": 626,
+              "NameEnd": 642
+            },
+            "Modifiers": [],
+            "Alias": null
+          }
+        ],
+        "From": {
+          "FromPos": 643,
+          "Expr": {
+            "Table": {
+              "TablePos": 648,
+              "TableEnd": 817,
+              "Alias": null,
+              "Expr": {
+                "HasParen": true,
+                "Select": {
+                  "SelectPos": 654,
+                  "StatementEnd": 817,
+                  "With": null,
+                  "Top": null,
+                  "HasDistinct": false,
+                  "DistinctOn": null,
+                  "SelectItems": [
+                    {
+                      "Expr": {
+                        "Name": "*",
+                        "QuoteType": 0,
+                        "NamePos": 669,
+                        "NameEnd": 669
+                      },
+                      "Modifiers": [],
+                      "Alias": null
+                    },
+                    {
+                      "Expr": {
+                        "Function": {
+                          "Name": {
+                            "Name": "row_number",
+                            "QuoteType": 1,
+                            "NamePos": 680,
+                            "NameEnd": 690
+                          },
+                          "Params": {
+                            "LeftParenPos": 690,
+                            "RightParenPos": 691,
+                            "Items": {
+                              "ListPos": 691,
+                              "ListEnd": 691,
+                              "HasDistinct": false,
+                              "Items": []
+                            },
+                            "ColumnArgList": null
+                          }
+                        },
+                        "OverPos": 693,
+                        "OverExpr": {
+                          "LeftParenPos": 698,
+                          "RightParenPos": 753,
+                          "WindowName": null,
+                          "PartitionBy": {
+                            "PartitionPos": 698,
+                            "Expr": {
+                              "ListPos": 712,
+                              "ListEnd": 728,
+                              "HasDistinct": false,
+                              "Items": [
+                                {
+                                  "Expr": {
+                                    "Name": "schedule_filters",
+                                    "QuoteType": 1,
+                                    "NamePos": 712,
+                                    "NameEnd": 728
+                                  },
+                                  "Alias": null
+                                }
+                              ]
+                            }
+                          },
+                          "OrderBy": {
+                            "OrderPos": 729,
+                            "ListEnd": 748,
+                            "Items": [
+                              {
+                                "OrderPos": 729,
+                                "Expr": {
+                                  "Name": "created_at",
+                                  "QuoteType": 1,
+                                  "NamePos": 738,
+                                  "NameEnd": 748
+                                },
+                                "Alias": null,
+                                "Direction": "DESC",
+                                "Fill": null
+                              }
+                            ],
+                            "Interpolate": null
+                          },
+                          "Frame": null
+                        }
+                      },
+                      "Modifiers": [],
+                      "Alias": {
+                        "Name": "rn",
+                        "QuoteType": 1,
+                        "NamePos": 758,
+                        "NameEnd": 760
+                      }
+                    }
+                  ],
+                  "From": {
+                    "FromPos": 765,
+                    "Expr": {
+                      "Table": {
+                        "TablePos": 770,
+                        "TableEnd": 783,
+                        "Alias": null,
+                        "Expr": {
+                          "Database": {
+                            "Name": "db1",
+                            "QuoteType": 1,
+                            "NamePos": 770,
+                            "NameEnd": 773
+                          },
+                          "Table": {
+                            "Name": "config_v0",
+                            "QuoteType": 1,
+                            "NamePos": 774,
+                            "NameEnd": 783
+                          }
+                        },
+                        "HasFinal": false
+                      },
+                      "StatementEnd": 783,
+                      "SampleRatio": null,
+                      "HasFinal": false
+                    }
+                  },
+                  "Window": null,
+                  "Prewhere": null,
+                  "Where": {
+                    "WherePos": 788,
+                    "Expr": {
+                      "LeftExpr": {
+                        "Name": "schedule_filters",
+                        "QuoteType": 1,
+                        "NamePos": 794,
+                        "NameEnd": 810
+                      },
+                      "Operation": "!=",
+                      "RightExpr": {
+                        "LiteralPos": 815,
+                        "LiteralEnd": 817,
+                        "Literal": "{}"
+                      },
+                      "HasGlobal": false,
+                      "HasNot": false
+                    }
+                  },
+                  "GroupBy": null,
+                  "WithTotal": false,
+                  "Having": null,
+                  "OrderBy": null,
+                  "LimitBy": null,
+                  "Limit": null,
+                  "Settings": null,
+                  "Format": null,
+                  "UnionAll": null,
+                  "UnionDistinct": null,
+                  "Except": null
+                }
+              },
+              "HasFinal": false
+            },
+            "StatementEnd": 817,
+            "SampleRatio": null,
+            "HasFinal": false
+          }
+        },
+        "Window": null,
+        "Prewhere": null,
+        "Where": {
+          "WherePos": 821,
+          "Expr": {
+            "LeftExpr": {
+              "Name": "rn",
+              "QuoteType": 1,
+              "NamePos": 827,
+              "NameEnd": 829
+            },
+            "Operation": "=",
+            "RightExpr": {
+              "NumPos": 832,
+              "NumEnd": 833,
+              "Literal": "1",
+              "Base": 10
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          }
+        },
+        "GroupBy": null,
+        "WithTotal": false,
+        "Having": null,
+        "OrderBy": null,
+        "LimitBy": null,
+        "Limit": null,
+        "Settings": null,
+        "Format": null,
+        "UnionAll": null,
+        "UnionDistinct": null,
+        "Except": null
+      }
+    },
+    "Populate": false,
+    "Comment": {
+      "LiteralPos": 466,
+      "LiteralEnd": 478,
+      "Literal": "test comment"
+    },
+    "Definer": {
+      "Name": "default",
+      "QuoteType": 1,
+      "NamePos": 428,
+      "NameEnd": 435
+    },
+    "SQLSecurity": "DEFINER"
+  }
+]

--- a/parser/testdata/ddl/output/create_materialized_view_with_comment_before_as.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_comment_before_as.sql.golden.json
@@ -24,6 +24,7 @@
     "Settings": null,
     "HasAppend": false,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 44,

--- a/parser/testdata/ddl/output/create_materialized_view_with_definer.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_definer.sql.golden.json
@@ -52,6 +52,7 @@
     "Settings": null,
     "HasAppend": true,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 79,

--- a/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_empty_table_schema.sql.golden.json
@@ -144,6 +144,7 @@
         "Interpolate": null
       }
     },
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": null,
     "SubQuery": {

--- a/parser/testdata/ddl/output/create_materialized_view_with_gcs.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_gcs.sql.golden.json
@@ -43,6 +43,7 @@
     "Settings": null,
     "HasAppend": false,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 80,

--- a/parser/testdata/ddl/output/create_materialized_view_with_refresh.sql.golden.json
+++ b/parser/testdata/ddl/output/create_materialized_view_with_refresh.sql.golden.json
@@ -126,6 +126,7 @@
     },
     "HasAppend": true,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": true,
     "Destination": {
       "ToPos": 207,

--- a/parser/testdata/ddl/output/create_mv_with_not_op.sql.golden.json
+++ b/parser/testdata/ddl/output/create_mv_with_not_op.sql.golden.json
@@ -31,6 +31,7 @@
     "Settings": null,
     "HasAppend": false,
     "Engine": null,
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": {
       "ToPos": 77,

--- a/parser/testdata/ddl/output/create_mv_with_order_by.sql.golden.json
+++ b/parser/testdata/ddl/output/create_mv_with_order_by.sql.golden.json
@@ -96,6 +96,7 @@
         "Interpolate": null
       }
     },
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": null,
     "SubQuery": {
@@ -227,6 +228,7 @@
       "Settings": null,
       "OrderBy": null
     },
+    "TableSchema": null,
     "HasEmpty": false,
     "Destination": null,
     "SubQuery": {

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -668,6 +668,9 @@ func Walk(node Expr, fn WalkFunc) bool {
 		if !Walk(n.Settings, fn) {
 			return false
 		}
+		if !Walk(n.TableSchema, fn) {
+			return false
+		}
 		if !Walk(n.Engine, fn) {
 			return false
 		}


### PR DESCRIPTION
## Problem

Two issues with `CREATE MATERIALIZED VIEW` parsing:

### 1. Column list before ENGINE fails (new syntax support)

ClickHouse `SHOW CREATE TABLE` for refreshable materialized views with `ENGINE` (e.g. Memory) outputs the column list between REFRESH and ENGINE:

```sql
CREATE MATERIALIZED VIEW db1.config_cache_v0
REFRESH EVERY 1 SECOND
(
    `id` String,
    `name` String,
    `value` Float64
)
ENGINE = Memory
AS SELECT id, name, value FROM db1.config_v0
```

**Before:** `line 2:0 unexpected token: "(", expected TO or ENGINE`

**After:** Parses correctly. Column list stored in `CreateMaterializedView.TableSchema`.

### 2. DEPENDS ON with multiple tables fails (bug fix)

```sql
CREATE MATERIALIZED VIEW db1.mv
REFRESH EVERY 5 MINUTE
DEPENDS ON db1.mv_a, db1.mv_b
ENGINE = Memory
AS SELECT 1
```

**Before:** `expected <ident> or <string>, but got ","`

**After:** Parses correctly. Both tables captured in `DependsOn` slice.

**Root cause:** The comma token was not consumed before parsing the next table identifier in the DEPENDS ON loop. The query parser (`parser_query.go`) has the correct pattern (`consumeToken()` after matching comma), but the view parser was missing it.

## ClickHouse syntax reference

```
CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name [ON CLUSTER cluster]
  [REFRESH EVERY|AFTER interval [OFFSET interval]]
  [RANDOMIZE FOR interval]
  [DEPENDS ON [db.]name [, [db.]name [, ...]]]
  [SETTINGS name = value [, ...]]
  [APPEND]
  [TO [db.]name] [(columns)] [ENGINE = engine]
  [EMPTY]
  [DEFINER = { user | CURRENT_USER }] [SQL SECURITY { DEFINER | NONE }]
  AS SELECT ...
  [COMMENT 'comment']
```

## Changes

| File | Change |
|------|--------|
| `parser/parser_view.go` | Handle `(` as column list before ENGINE; add `consumeToken()` for comma in DEPENDS ON |
| `parser/ast.go` | Add `TableSchema *TableSchemaClause` to `CreateMaterializedView` |
| `parser/format.go` | Emit `TableSchema` before `ENGINE` |
| `parser/walk.go` | Traverse `TableSchema` in Walk |

## Tests

Added 2 test fixtures:
- `create_materialized_view_rmv_engine_with_columns.sql` — REFRESH + column list + ENGINE + SETTINGS + DEFINER + COMMENT + subquery
- `create_materialized_view_rmv_depends_on_multi.sql` — REFRESH + multi-table DEPENDS ON + ENGINE

Validated 21 MV syntax variants covering all combinations. All existing tests pass.