### PR TITLE
Fix infinite loop (DoS hang) on unterminated block comment

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -237,7 +237,7 @@ func (l *Lexer) consumeSingleLineComment() {
 func (l *Lexer) consumeMultiLineComment() {
 	l.skipN(2)
 	i := 0
-	for !l.isEOF() {
+	for l.peekOk(i) {
 		if l.peekOk(i+1) && l.peekN(i) == '*' && l.peekN(i+1) == '/' {
 			i += 2
 			break

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,38 @@ func TestConsumeComment(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+}
+
+// TestConsumeUnterminatedComment guards against an infinite loop (a DoS hang)
+// when a block comment is never closed. consumeMultiLineComment previously
+// looped on isEOF() while only advancing a local index, so l.current never
+// reached EOF and the lexer spun forever. The test runs in a goroutine with a
+// timeout so a regression fails fast instead of hanging the whole test binary.
+func TestConsumeUnterminatedComment(t *testing.T) {
+	inputs := []string{
+		"/*",
+		"/* unterminated",
+		"/* unterminated *",
+		"SELECT 1 /* unterminated",
+	}
+	for _, c := range inputs {
+		c := c
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			lexer := NewLexer(c)
+			for !lexer.isEOF() {
+				if err := lexer.consumeToken(); err != nil {
+					break
+				}
+			}
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("lexer did not terminate on unterminated comment: %q", c)
+		}
+	}
 }
 
 func TestConsumeString(t *testing.T) {


### PR DESCRIPTION
## Problem

`consumeMultiLineComment` loops on `!l.isEOF()`, which tests `l.current`, but only advances a **local** index `i`. When a block comment is never closed, `l.current` never moves, so `isEOF()` never becomes true and the lexer spins forever — a denial-of-service **hang** on malformed input.

## Reproduction

```go
parser.NewParser("/* unterminated").ParseStmts() // hangs forever
parser.NewParser("SELECT 1 /* x").ParseStmts()   // hangs forever
```

(The exact 2-byte input `/*` is safe because `skipN(2)` already leaves `current` at EOF, but any content after the opener triggers the hang.)

## Fix

Loop on `l.peekOk(i)` instead, so the loop tracks the local index and terminates at end of input. When no closing `*/` is found, the remainder is consumed as comment — matching `consumeSingleLineComment`'s behaviour.

## Test

`TestConsumeUnterminatedComment` drains the lexer in a goroutine guarded by a timeout, so a regression fails fast instead of hanging the test binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)