### PR TITLE
Fix index-out-of-range panic in wrapError at EOF

### DIFF
--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -374,7 +374,13 @@ func (p *Parser) wrapError(err error) error {
 	lineNo := 0
 	column := 0
 
-	for i := 0; i < int(p.Pos()); i++ {
+	// p.Pos() can exceed the input length when the lexer is at EOF,
+	// so clamp the upper bound to avoid an index-out-of-range panic.
+	upperBound := int(p.Pos())
+	if upperBound > len(p.lexer.input) {
+		upperBound = len(p.lexer.input)
+	}
+	for i := 0; i < upperBound; i++ {
 		if p.lexer.input[i] == '\n' {
 			lineNo++
 			column = 0

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -186,7 +186,8 @@ func TestParser_InvalidSyntax(t *testing.T) {
 		// Invalid ARRAY JOIN types (only ARRAY JOIN, LEFT ARRAY JOIN, and INNER ARRAY JOIN are valid)
 		"SELECT * FROM t RIGHT ARRAY JOIN arr AS a", // RIGHT ARRAY JOIN not supported
 		"SELECT * FROM t FULL ARRAY JOIN arr AS a",  // FULL ARRAY JOIN not supported
-		"00e1d", // invalid number that leaves lastToken nil
+		"00e1d",    // invalid number that leaves lastToken nil
+		"CREATE--", // trailing comment pushes p.Pos() past end of input (wrapError out-of-range)
 	}
 	for _, sql := range invalidSQLs {
 		parser := NewParser(sql)


### PR DESCRIPTION
## Problem

`wrapError` computes the error line/column by walking the input:

```go
for i := 0; i < int(p.Pos()); i++ {
    if p.lexer.input[i] == '\n' { ... }
}
```

At end of input `p.Pos()` can be **larger** than `len(p.lexer.input)`, so indexing `p.lexer.input[i]` panics.

## Reproduction

```go
parser.NewParser("CREATE--").ParseStmts()
// panic: runtime error: index out of range [8] with length 8
```

The trailing `--` comment leaves the lexer position past the end of the 8-byte input.

## Fix

Clamp the loop's upper bound to `len(p.lexer.input)`.

## Test

`CREATE--` added to `TestParser_InvalidSyntax`; it panicked before the fix and now returns a proper error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)