### PR TITLE
Fix nil-pointer dereference when formatting errors at EOF

### DIFF
--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -691,7 +691,7 @@ func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
 		}, nil
 	default:
 		return nil, fmt.Errorf("expected keyword: COLUMN|TTL|QUERY|SETTING, but got %q",
-			p.last().String)
+			p.lastTokenString())
 	}
 
 }

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -23,6 +23,16 @@ func (p *Parser) lastTokenKind() TokenKind {
 	return p.last().Kind
 }
 
+// lastTokenString returns the string of the last token, or "<EOF>" when the
+// lexer has no current token. Use this on error paths where the last token may
+// be nil (e.g. at end of input) to avoid a nil-pointer dereference.
+func (p *Parser) lastTokenString() string {
+	if p.last() == nil {
+		return "<EOF>"
+	}
+	return p.last().String
+}
+
 func (p *Parser) last() *Token {
 	return p.lexer.lastToken
 }

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -12,7 +12,7 @@ func (p *Parser) parseDDL(pos Pos) (DDL, error) {
 		_ = p.lexer.consumeToken()
 		orReplace := p.tryConsumeKeywords(KeywordOr, KeywordReplace)
 		if orReplace && !p.matchOneOfKeywords(KeywordTemporary, KeywordTable, KeywordView, KeywordFunction, KeywordDictionary) {
-			return nil, fmt.Errorf("expected keyword: TEMPORARY|TABLE|VIEW|FUNCTION|DICTIONARY, but got %q", p.last().String)
+			return nil, fmt.Errorf("expected keyword: TEMPORARY|TABLE|VIEW|FUNCTION|DICTIONARY, but got %q", p.lastTokenString())
 		}
 		switch {
 		case p.matchKeyword(KeywordNamed):
@@ -48,7 +48,7 @@ func (p *Parser) parseDDL(pos Pos) (DDL, error) {
 		case p.matchKeyword(KeywordTable):
 			return p.parseAlterTable(pos)
 		default:
-			return nil, fmt.Errorf("expected keyword: TABLE|ROLE, but got %q", p.last().String)
+			return nil, fmt.Errorf("expected keyword: TABLE|ROLE, but got %q", p.lastTokenString())
 		}
 	case p.matchKeyword(KeywordDrop),
 		p.matchKeyword(KeywordDetach):
@@ -65,7 +65,7 @@ func (p *Parser) parseDDL(pos Pos) (DDL, error) {
 			p.matchKeyword(KeywordRole):
 			return p.parserDropUserOrRole(pos)
 		default:
-			return nil, fmt.Errorf("expected keyword: DATABASE|TABLE, but got %q", p.last().String)
+			return nil, fmt.Errorf("expected keyword: DATABASE|TABLE, but got %q", p.lastTokenString())
 		}
 	case p.matchKeyword(KeywordTruncate):
 		return p.parseTruncateTable(pos)
@@ -761,7 +761,7 @@ func (p *Parser) parseTableArgExpr(pos Pos) (Expr, error) {
 	case p.matchTokenKind(TokenKindInt), p.matchTokenKind(TokenKindString), p.matchKeyword(KeywordNull):
 		return p.parseLiteral(p.Pos())
 	default:
-		return nil, fmt.Errorf("unexpected token: %q, expected <Name>, <literal>", p.last().String)
+		return nil, fmt.Errorf("unexpected token: %q, expected <Name>, <literal>", p.lastTokenString())
 	}
 }
 
@@ -855,7 +855,7 @@ func (p *Parser) tryParseClusterClause(pos Pos) (*ClusterClause, error) {
 	case p.matchTokenKind(TokenKindString):
 		expr, err = p.parseString(p.Pos())
 	default:
-		return nil, fmt.Errorf("unexpected token: %q, expected <IDENT> or <STRING>", p.last().String)
+		return nil, fmt.Errorf("unexpected token: %q, expected <IDENT> or <STRING>", p.lastTokenString())
 	}
 	if err != nil {
 		return nil, err
@@ -1303,7 +1303,7 @@ func (p *Parser) parseSettingsExpr(pos Pos) (*SettingExpr, error) {
 			Literal:    lastToken.String,
 		}
 	default:
-		return nil, fmt.Errorf("unexpected token: %q, expected <number>, <bool> or <string>", p.last().String)
+		return nil, fmt.Errorf("unexpected token: %q, expected <number>, <bool> or <string>", p.lastTokenString())
 	}
 
 	return &SettingExpr{
@@ -1458,7 +1458,7 @@ func (p *Parser) parseStmt(pos Pos) (Expr, error) {
 		if p.last() == nil {
 			return nil, errors.New("unexpected end of input")
 		}
-		return nil, fmt.Errorf("unexpected token: %q", p.last().String)
+		return nil, fmt.Errorf("unexpected token: %q", p.lastTokenString())
 	}
 	if err != nil {
 		return nil, err
@@ -1470,7 +1470,7 @@ func (p *Parser) parseStmt(pos Pos) (Expr, error) {
 
 	// Statement can be terminated by ';' or EOF
 	if p.last() != nil && !p.matchTokenKind(";") {
-		return nil, fmt.Errorf("<EOF> or ';' was expected, but got: %q", p.last().String)
+		return nil, fmt.Errorf("<EOF> or ';' was expected, but got: %q", p.lastTokenString())
 	}
 	return expr, nil
 }
@@ -1550,7 +1550,7 @@ func (p *Parser) parseShowStmt(pos Pos) (*ShowStmt, error) {
 		_ = p.lexer.consumeToken()
 
 	default:
-		return nil, fmt.Errorf("expected CREATE, DATABASES, or TABLES after SHOW, got %q", p.last().String)
+		return nil, fmt.Errorf("expected CREATE, DATABASES, or TABLES after SHOW, got %q", p.lastTokenString())
 	}
 
 	stmt := &ShowStmt{
@@ -1629,7 +1629,7 @@ func (p *Parser) parseShowStmt(pos Pos) (*ShowStmt, error) {
 					Literal:    token.String,
 				}
 			} else {
-				return nil, fmt.Errorf("expected format specification after FORMAT, got %q", p.last().String)
+				return nil, fmt.Errorf("expected format specification after FORMAT, got %q", p.lastTokenString())
 			}
 		}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -187,6 +187,11 @@ func TestParser_InvalidSyntax(t *testing.T) {
 		"SELECT * FROM t RIGHT ARRAY JOIN arr AS a", // RIGHT ARRAY JOIN not supported
 		"SELECT * FROM t FULL ARRAY JOIN arr AS a",  // FULL ARRAY JOIN not supported
 		"00e1d", // invalid number that leaves lastToken nil
+		// Inputs that previously caused a nil-pointer dereference while
+		// formatting the error message at EOF (p.last() is nil).
+		"ALTER ",
+		"SELECT*FROM A(0A",
+		"SET A=",
 	}
 	for _, sql := range invalidSQLs {
 		parser := NewParser(sql)


### PR DESCRIPTION
## Problem

Error messages of the form `fmt.Errorf("... %q", p.last().String)` panic when the lexer is at EOF, because `p.last()` returns `nil`. There were 11 such unguarded uses across `parser_table.go` and `parser_alter.go`.

## Reproduction

```go
parser.NewParser("ALTER ").ParseStmts()
parser.NewParser("SELECT*FROM A(0A").ParseStmts()
parser.NewParser("SET A=").ParseStmts()
// each: panic: runtime error: invalid memory address or nil pointer dereference
```

## Fix

Add a nil-safe `lastTokenString()` helper (mirroring the existing `lastTokenKind()`) that returns `"<EOF>"` when there is no current token, and use it in the 11 error paths. The ~50 success-path uses of `p.last().String`, where `last()` is provably non-nil after a successful match, are left untouched.

## Test

`ALTER `, `SELECT*FROM A(0A`, `SET A=` added to `TestParser_InvalidSyntax`; each panicked before the fix and now returns a proper error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)