### PR TITLE
Split keywords into reserved and non-reserved sets

### DIFF
--- a/parser/keyword.go
+++ b/parser/keyword.go
@@ -259,6 +259,70 @@ const (
 	KeywordSecurity     = "SECURITY"
 )
 
+// reservedKeywords are the structural keywords — statement starters, clause
+// starters and expression operators — that cannot be used as bare identifiers:
+// letting them match identifier positions makes a missing name silently swallow
+// the next clause (e.g. `SELECT a FROM WHERE b = 1` parsing FROM as an alias).
+// Every other keyword is non-reserved and is accepted anywhere an identifier
+// is expected (see Parser.matchTokenKind). Positions where even a reserved
+// keyword is provably used as a name — after AS, after a dot in a qualified
+// name, or a lookahead-disambiguated select item — use parseIdentAnyKeyword.
+//
+// Keywords that double as ClickHouse function or engine names (IF, LEFT,
+// RIGHT, ANY, MIN, MAX, TRIM, SET, JOIN...) must stay non-reserved.
+var reservedKeywords = NewSet(
+	KeywordAlter,
+	KeywordAnd,
+	KeywordAs,
+	KeywordBetween,
+	KeywordBy,
+	KeywordCase,
+	KeywordCreate,
+	KeywordCross,
+	KeywordDescribe,
+	KeywordDistinct,
+	KeywordDrop,
+	KeywordElse,
+	KeywordEnd,
+	KeywordExcept,
+	KeywordExplain,
+	KeywordFormat,
+	KeywordFrom,
+	KeywordGrant,
+	KeywordGroup,
+	KeywordHaving,
+	KeywordIlike,
+	KeywordIn,
+	KeywordInner,
+	KeywordInsert,
+	KeywordInterval,
+	KeywordInto,
+	KeywordIs,
+	KeywordKill,
+	KeywordLike,
+	KeywordLimit,
+	KeywordNot,
+	KeywordOffset,
+	KeywordOn,
+	KeywordOptimize,
+	KeywordOr,
+	KeywordOrder,
+	KeywordPrewhere,
+	KeywordRename,
+	KeywordSelect,
+	KeywordSettings,
+	KeywordShow,
+	KeywordThen,
+	KeywordTruncate,
+	KeywordUnion,
+	KeywordUse,
+	KeywordUsing,
+	KeywordWhen,
+	KeywordWhere,
+	KeywordWindow,
+	KeywordWith,
+)
+
 var keywords = NewSet(
 	KeywordAdd,
 	KeywordAdmin,

--- a/parser/keyword.go
+++ b/parser/keyword.go
@@ -266,7 +266,7 @@ const (
 // Every other keyword is non-reserved and is accepted anywhere an identifier
 // is expected (see Parser.matchTokenKind). Positions where even a reserved
 // keyword is provably used as a name — after AS, after a dot in a qualified
-// name, or a lookahead-disambiguated select item — use parseIdentAnyKeyword.
+// name, or a lookahead-disambiguated select item — use parseAnyKeyword.
 //
 // Keywords that double as ClickHouse function or engine names (IF, LEFT,
 // RIGHT, ANY, MIN, MAX, TRIM, SET, JOIN...) must stay non-reserved.

--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -70,6 +70,7 @@ func TestReservedKeywordInDisambiguatedPositions(t *testing.T) {
 		"SELECT limit",
 		"SELECT a FROM t WHERE ts < {end:UInt32}",
 		"SELECT sum(x) OVER (order) FROM t WINDOW order AS (PARTITION BY team)",
+		"SELECT sum(x) OVER order FROM t WINDOW order AS (PARTITION BY team)",
 		"GRANT SELECT(x) ON db.table TO john WITH GRANT OPTION",
 	}
 	for _, sql := range cases {

--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservedKeywordsAreKeywords(t *testing.T) {
+	for _, kw := range reservedKeywords.Members() {
+		require.True(t, keywords.Contains(kw),
+			"reserved keyword %q is missing from the keywords set", kw)
+	}
+}
+
+// TestReservedKeywordRejectedAsIdentifier asserts that a reserved keyword no
+// longer silently fills an identifier slot: a missing name before a clause
+// keyword must fail at the keyword instead of swallowing it (the bug class
+// behind #268/#269: e.g. `SELECT a FROM WHERE b = 1` used to parse FROM as a
+// bare alias of `a`).
+func TestReservedKeywordRejectedAsIdentifier(t *testing.T) {
+	cases := []string{
+		"SELECT a FROM WHERE b = 1",                  // FROM must not become an alias of `a`
+		"SELECT a, b FROM GROUP BY a",                // FROM must not become an alias of `b`
+		"INSERT INTO SELECT 1",                       // SELECT must not become a table name
+		"SELECT a AS FROM t",                         // explicit alias FROM consumes the clause keyword
+		"SELECT a FROM t JOIN ON a = b",              // ON must not become a table name
+		"CREATE TABLE t (from String) ENGINE=Memory", // reserved keyword as column name needs quoting
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestNonReservedKeywordAsIdentifier asserts that non-reserved keywords keep
+// working as identifiers anywhere an identifier is expected.
+func TestNonReservedKeywordAsIdentifier(t *testing.T) {
+	cases := []string{
+		"SELECT key FROM t",
+		"SELECT date, first, last, timestamp FROM t",
+		"CREATE TABLE t (key String, date Date) ENGINE=Memory",
+		"SELECT t.key FROM t",
+		"SELECT if(a, 1, 2), any(b), left(c, 1) FROM t",
+		"SELECT * FROM t WHERE key = 1",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestReservedKeywordInDisambiguatedPositions asserts that reserved keywords
+// are still accepted as names where context proves they cannot start a clause:
+// after AS, after a dot in a qualified name, lookahead-disambiguated select
+// items, query parameters, window names, and GRANT options.
+func TestReservedKeywordInDisambiguatedPositions(t *testing.T) {
+	cases := []string{
+		"SELECT 1 AS from",
+		"SELECT 1 AS interval, 2 AS from, 3 AS limit",
+		"SELECT * FROM t AS from",
+		"SELECT a FROM db.from",
+		"SELECT t.from FROM t",
+		"SELECT a, limit FROM t",
+		"SELECT case;",
+		"SELECT limit",
+		"SELECT a FROM t WHERE ts < {end:UInt32}",
+		"SELECT sum(x) OVER (order) FROM t WINDOW order AS (PARTITION BY team)",
+		"GRANT SELECT(x) ON db.table TO john WITH GRANT OPTION",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.NoError(t, err)
+		})
+	}
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -57,31 +57,6 @@ const (
 type Pos int
 type TokenKind string
 
-// kindClass is a bit set over token kinds, enabling multi-kind membership
-// checks in a single expression, e.g. matchTokenKindIn(classIdent | classKeyword).
-// TokenKind itself stays a string (its values are woven into the public AST
-// and error messages), so kinds that participate in such checks get a class
-// bit here instead.
-type kindClass uint8
-
-const (
-	classIdent kindClass = 1 << iota
-	classKeyword
-)
-
-// class maps a TokenKind to its kindClass bit; kinds without a class
-// (operators, punctuation, EOF) map to 0.
-func (k TokenKind) class() kindClass {
-	switch k {
-	case TokenKindIdent:
-		return classIdent
-	case TokenKindKeyword:
-		return classKeyword
-	default:
-		return 0
-	}
-}
-
 type Token struct {
 	Pos Pos
 	End Pos

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -57,6 +57,31 @@ const (
 type Pos int
 type TokenKind string
 
+// kindClass is a bit set over token kinds, enabling multi-kind membership
+// checks in a single expression, e.g. matchTokenKindIn(classIdent | classKeyword).
+// TokenKind itself stays a string (its values are woven into the public AST
+// and error messages), so kinds that participate in such checks get a class
+// bit here instead.
+type kindClass uint8
+
+const (
+	classIdent kindClass = 1 << iota
+	classKeyword
+)
+
+// class maps a TokenKind to its kindClass bit; kinds without a class
+// (operators, punctuation, EOF) map to 0.
+func (k TokenKind) class() kindClass {
+	switch k {
+	case TokenKindIdent:
+		return classIdent
+	case TokenKindKeyword:
+		return classKeyword
+	default:
+		return 0
+	}
+}
+
 type Token struct {
 	Pos Pos
 	End Pos

--- a/parser/parse_system.go
+++ b/parser/parse_system.go
@@ -1278,7 +1278,9 @@ func (p *Parser) parseGrantOption(_ Pos) (string, error) {
 	if err := p.expectKeyword(KeywordWith); err != nil {
 		return "", err
 	}
-	ident, err := p.parseIdent()
+	// Between WITH and OPTION the token can only be the option name, which may
+	// be a reserved keyword (e.g. `WITH GRANT OPTION`).
+	ident, err := p.parseIdentAnyKeyword()
 	if err != nil {
 		return "", err
 	}

--- a/parser/parse_system.go
+++ b/parser/parse_system.go
@@ -1280,7 +1280,7 @@ func (p *Parser) parseGrantOption(_ Pos) (string, error) {
 	}
 	// Between WITH and OPTION the token can only be the option name, which may
 	// be a reserved keyword (e.g. `WITH GRANT OPTION`).
-	ident, err := p.parseIdentAnyKeyword()
+	ident, err := p.parseAnyKeyword()
 	if err != nil {
 		return "", err
 	}

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -152,8 +152,10 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		// access column with dot notation
 		var rightExpr Expr
 		var err error
-		if p.matchTokenKind(TokenKindIdent) {
-			rightExpr, err = p.parseIdent()
+		if p.lastTokenKind() == TokenKindIdent || p.lastTokenKind() == TokenKindKeyword {
+			// After a dot the token can only be a member name, so even
+			// reserved keywords are accepted (e.g. `t.from`).
+			rightExpr, err = p.parseIdentAnyKeyword()
 		} else {
 			rightExpr, err = p.parseDecimal(p.Pos())
 		}
@@ -472,7 +474,7 @@ func (p *Parser) parseColumnExpr(pos Pos) (Expr, error) { //nolint:funlen
 	// terminator/alias check).
 	if p.keywordIsSelectItemIdentifier() ||
 		(p.matchTokenKind(TokenKindKeyword) && p.peekIsEndOfStatement()) {
-		return p.parseIdent()
+		return p.parseIdentAnyKeyword()
 	}
 	switch {
 	case p.matchKeyword(KeywordInterval):
@@ -676,8 +678,10 @@ func (p *Parser) parseInterval(requireKeyword bool) (*IntervalExpr, error) {
 }
 
 func (p *Parser) parseFunctionExpr(_ Pos) (*FunctionExpr, error) {
-	// parse function name
-	name, err := p.parseIdent()
+	// parse function name; callers gate entry (select-item modifiers match
+	// EXCEPT/APPLY/REPLACE first, INSERT INTO FUNCTION follows the FUNCTION
+	// keyword), so even reserved keywords are valid names here.
+	name, err := p.parseIdentAnyKeyword()
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +798,9 @@ func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
 		return nil, err
 	}
 
-	ident, err := p.parseIdent()
+	// Inside `{name:Type}` the token can only be the parameter name, so even
+	// reserved keywords are accepted (e.g. `{end:UInt32}`).
+	ident, err := p.parseIdentAnyKeyword()
 	if err != nil {
 		return nil, err
 	}
@@ -877,15 +883,16 @@ func (p *Parser) parseSelectItem() (*SelectItem, error) {
 	var alias *Ident
 	switch {
 	case p.tryConsumeKeywords(KeywordAs):
-		// `SELECT 1 AS <reserved-keyword>` works for any keyword because
-		// matchTokenKind(TokenKindIdent) coerces TokenKindKeyword to ident
-		// (see parser_common.go matchTokenKind), so parseIdent accepts a
-		// keyword token here without needing a special-case.
-		alias, err = p.parseIdent()
+		// `SELECT 1 AS <keyword>` works for any keyword, reserved or not:
+		// after AS the token can only be an alias name.
+		alias, err = p.parseIdentAnyKeyword()
 		if err != nil {
 			return nil, err
 		}
-	case p.lastTokenKind() == TokenKindKeyword && !p.isSelectItemTerminatorKeyword():
+	case p.lastTokenKind() == TokenKindKeyword &&
+		p.matchTokenKind(TokenKindIdent) && !p.isSelectItemTerminatorKeyword():
+		// Only a non-reserved keyword can be a bare (no-AS) alias; a reserved
+		// keyword here starts the next clause (e.g. `SELECT a FROM ...`).
 		alias, err = p.parseIdent()
 		if err != nil {
 			return nil, err

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -152,10 +152,10 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		// access column with dot notation
 		var rightExpr Expr
 		var err error
-		if p.lastTokenKind() == TokenKindIdent || p.lastTokenKind() == TokenKindKeyword {
+		if p.matchTokenKindIn(classIdent | classKeyword) {
 			// After a dot the token can only be a member name, so even
 			// reserved keywords are accepted (e.g. `t.from`).
-			rightExpr, err = p.parseIdentAnyKeyword()
+			rightExpr, err = p.parseAnyKeyword()
 		} else {
 			rightExpr, err = p.parseDecimal(p.Pos())
 		}
@@ -474,7 +474,7 @@ func (p *Parser) parseColumnExpr(pos Pos) (Expr, error) { //nolint:funlen
 	// terminator/alias check).
 	if p.keywordIsSelectItemIdentifier() ||
 		(p.matchTokenKind(TokenKindKeyword) && p.peekIsEndOfStatement()) {
-		return p.parseIdentAnyKeyword()
+		return p.parseAnyKeyword()
 	}
 	switch {
 	case p.matchKeyword(KeywordInterval):
@@ -681,7 +681,7 @@ func (p *Parser) parseFunctionExpr(_ Pos) (*FunctionExpr, error) {
 	// parse function name; callers gate entry (select-item modifiers match
 	// EXCEPT/APPLY/REPLACE first, INSERT INTO FUNCTION follows the FUNCTION
 	// keyword), so even reserved keywords are valid names here.
-	name, err := p.parseIdentAnyKeyword()
+	name, err := p.parseAnyKeyword()
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +800,7 @@ func (p *Parser) parseQueryParam(pos Pos) (*QueryParam, error) {
 
 	// Inside `{name:Type}` the token can only be the parameter name, so even
 	// reserved keywords are accepted (e.g. `{end:UInt32}`).
-	ident, err := p.parseIdentAnyKeyword()
+	ident, err := p.parseAnyKeyword()
 	if err != nil {
 		return nil, err
 	}
@@ -885,7 +885,7 @@ func (p *Parser) parseSelectItem() (*SelectItem, error) {
 	case p.tryConsumeKeywords(KeywordAs):
 		// `SELECT 1 AS <keyword>` works for any keyword, reserved or not:
 		// after AS the token can only be an alias name.
-		alias, err = p.parseIdentAnyKeyword()
+		alias, err = p.parseAnyKeyword()
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -152,7 +152,7 @@ func (p *Parser) parseInfix(expr Expr, precedence int) (Expr, error) {
 		// access column with dot notation
 		var rightExpr Expr
 		var err error
-		if p.matchTokenKindIn(classIdent | classKeyword) {
+		if p.matchTokenKind(TokenKindIdent, TokenKindKeyword) {
 			// After a dot the token can only be a member name, so even
 			// reserved keywords are accepted (e.g. `t.from`).
 			rightExpr, err = p.parseAnyKeyword()

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -77,6 +77,13 @@ func (p *Parser) matchTokenKind(kind TokenKind) bool {
 		!reservedKeywords.Contains(strings.ToUpper(p.last().String))
 }
 
+// matchTokenKindIn reports whether the current token's kind is in the given
+// class set, e.g. matchTokenKindIn(classIdent | classKeyword). Unlike
+// matchTokenKind it is a raw kind check: no keyword-to-identifier coercion.
+func (p *Parser) matchTokenKindIn(classes kindClass) bool {
+	return p.lastTokenKind().class()&classes != 0
+}
+
 // expectTokenKind consumes the last token if it is the given kind.
 func (p *Parser) expectTokenKind(kind TokenKind) error {
 	if lastToken := p.tryConsumeTokenKind(kind); lastToken != nil {
@@ -149,14 +156,14 @@ func (p *Parser) tryParseIdent() *Ident {
 	}
 }
 
-// parseIdentAnyKeyword parses the current token as an identifier, accepting
+// parseAnyKeyword parses the current token as an identifier, accepting
 // any keyword token — reserved or not — as the name. Use it only in positions
 // where context has already proven the token is a name and not the start of a
 // clause or expression: after AS, after a dot in a qualified name, or a select
 // item the lookahead disambiguated.
-func (p *Parser) parseIdentAnyKeyword() (*Ident, error) {
+func (p *Parser) parseAnyKeyword() (*Ident, error) {
 	last := p.last()
-	if last == nil || (last.Kind != TokenKindIdent && last.Kind != TokenKindKeyword) {
+	if !p.matchTokenKindIn(classIdent | classKeyword) {
 		return nil, &ParseError{
 			Pos:      p.Pos(),
 			Got:      last,
@@ -227,7 +234,7 @@ func (p *Parser) tryParseDotIdent(_ Pos) (*Ident, error) {
 	}
 	// After a dot the token can only be a member name, so even reserved
 	// keywords are accepted (e.g. `db.from`, `t.limit`).
-	return p.parseIdentAnyKeyword()
+	return p.parseAnyKeyword()
 }
 
 func (p *Parser) tryParseDotIdentOrString(_ Pos) (*Ident, error) {
@@ -237,7 +244,7 @@ func (p *Parser) tryParseDotIdentOrString(_ Pos) (*Ident, error) {
 	// After a dot the token can only be a member name, so even reserved
 	// keywords are accepted (e.g. `db.from`).
 	if p.lastTokenKind() == TokenKindKeyword {
-		return p.parseIdentAnyKeyword()
+		return p.parseAnyKeyword()
 	}
 	return p.parseIdentOrString()
 }

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -62,9 +62,19 @@ func (p *Parser) Pos() Pos {
 	return last.Pos
 }
 
+// matchTokenKind reports whether the current token matches the given kind.
+// A non-reserved keyword also matches TokenKindIdent: most ClickHouse keywords
+// (DATE, KEY, FIRST, ...) are valid identifiers anywhere an identifier is
+// expected. Reserved keywords (see reservedKeywords) do not match, so a
+// missing identifier before e.g. FROM or WHERE fails fast instead of silently
+// swallowing the clause keyword as a name.
 func (p *Parser) matchTokenKind(kind TokenKind) bool {
-	return p.lastTokenKind() == kind ||
-		(kind == TokenKindIdent && p.lastTokenKind() == TokenKindKeyword)
+	if p.lastTokenKind() == kind {
+		return true
+	}
+	return kind == TokenKindIdent &&
+		p.lastTokenKind() == TokenKindKeyword &&
+		!reservedKeywords.Contains(strings.ToUpper(p.last().String))
 }
 
 // expectTokenKind consumes the last token if it is the given kind.
@@ -139,6 +149,29 @@ func (p *Parser) tryParseIdent() *Ident {
 	}
 }
 
+// parseIdentAnyKeyword parses the current token as an identifier, accepting
+// any keyword token — reserved or not — as the name. Use it only in positions
+// where context has already proven the token is a name and not the start of a
+// clause or expression: after AS, after a dot in a qualified name, or a select
+// item the lookahead disambiguated.
+func (p *Parser) parseIdentAnyKeyword() (*Ident, error) {
+	last := p.last()
+	if last == nil || (last.Kind != TokenKindIdent && last.Kind != TokenKindKeyword) {
+		return nil, &ParseError{
+			Pos:      p.Pos(),
+			Got:      last,
+			Expected: []TokenKind{TokenKindIdent},
+		}
+	}
+	_ = p.lexer.consumeToken()
+	return &Ident{
+		NamePos:   last.Pos,
+		NameEnd:   last.End,
+		Name:      last.String,
+		QuoteType: last.QuoteType,
+	}, nil
+}
+
 func (p *Parser) parseIdent() (*Ident, error) {
 	lastToken := p.last()
 	if err := p.expectTokenKind(TokenKindIdent); err != nil {
@@ -192,12 +225,19 @@ func (p *Parser) tryParseDotIdent(_ Pos) (*Ident, error) {
 	if p.tryConsumeTokenKind(TokenKindDot) == nil {
 		return nil, nil // nolint
 	}
-	return p.parseIdent()
+	// After a dot the token can only be a member name, so even reserved
+	// keywords are accepted (e.g. `db.from`, `t.limit`).
+	return p.parseIdentAnyKeyword()
 }
 
 func (p *Parser) tryParseDotIdentOrString(_ Pos) (*Ident, error) {
 	if p.tryConsumeTokenKind(TokenKindDot) == nil {
 		return nil, nil // nolint
+	}
+	// After a dot the token can only be a member name, so even reserved
+	// keywords are accepted (e.g. `db.from`).
+	if p.lastTokenKind() == TokenKindKeyword {
+		return p.parseIdentAnyKeyword()
 	}
 	return p.parseIdentOrString()
 }

--- a/parser/parser_common.go
+++ b/parser/parser_common.go
@@ -62,26 +62,30 @@ func (p *Parser) Pos() Pos {
 	return last.Pos
 }
 
-// matchTokenKind reports whether the current token matches the given kind.
-// A non-reserved keyword also matches TokenKindIdent: most ClickHouse keywords
-// (DATE, KEY, FIRST, ...) are valid identifiers anywhere an identifier is
-// expected. Reserved keywords (see reservedKeywords) do not match, so a
-// missing identifier before e.g. FROM or WHERE fails fast instead of silently
-// swallowing the clause keyword as a name.
-func (p *Parser) matchTokenKind(kind TokenKind) bool {
-	if p.lastTokenKind() == kind {
-		return true
+// matchTokenKind reports whether the current token matches any of the given
+// kinds. A non-reserved keyword also matches TokenKindIdent: most ClickHouse
+// keywords (DATE, KEY, FIRST, ...) are valid identifiers anywhere an
+// identifier is expected. Reserved keywords (see reservedKeywords) do not
+// match TokenKindIdent, so a missing identifier before e.g. FROM or WHERE
+// fails fast instead of silently swallowing the clause keyword as a name; use
+// matchTokenKind(TokenKindIdent, TokenKindKeyword) where any keyword -
+// reserved or not - is acceptable.
+func (p *Parser) matchTokenKind(kinds ...TokenKind) bool {
+	cur := p.lastTokenKind()
+	for _, kind := range kinds {
+		if cur == kind {
+			return true
+		}
 	}
-	return kind == TokenKindIdent &&
-		p.lastTokenKind() == TokenKindKeyword &&
-		!reservedKeywords.Contains(strings.ToUpper(p.last().String))
-}
-
-// matchTokenKindIn reports whether the current token's kind is in the given
-// class set, e.g. matchTokenKindIn(classIdent | classKeyword). Unlike
-// matchTokenKind it is a raw kind check: no keyword-to-identifier coercion.
-func (p *Parser) matchTokenKindIn(classes kindClass) bool {
-	return p.lastTokenKind().class()&classes != 0
+	if cur != TokenKindKeyword {
+		return false
+	}
+	for _, kind := range kinds {
+		if kind == TokenKindIdent {
+			return !reservedKeywords.Contains(strings.ToUpper(p.last().String))
+		}
+	}
+	return false
 }
 
 // expectTokenKind consumes the last token if it is the given kind.
@@ -163,7 +167,7 @@ func (p *Parser) tryParseIdent() *Ident {
 // item the lookahead disambiguated.
 func (p *Parser) parseAnyKeyword() (*Ident, error) {
 	last := p.last()
-	if !p.matchTokenKindIn(classIdent | classKeyword) {
+	if !p.matchTokenKind(TokenKindIdent, TokenKindKeyword) {
 		return nil, &ParseError{
 			Pos:      p.Pos(),
 			Got:      last,

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -863,10 +863,10 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 }
 
 func (p *Parser) canParseWindowNameInParens() bool {
-	if !p.matchTokenKindIn(classIdent | classKeyword) {
+	if !p.matchTokenKind(TokenKindIdent, TokenKindKeyword) {
 		return false
 	}
-	if !p.matchTokenKindIn(classKeyword) {
+	if !p.matchTokenKind(TokenKindKeyword) {
 		return true
 	}
 

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -401,7 +401,7 @@ func (p *Parser) parseTableExpr(pos Pos) (*TableExpr, error) {
 	if p.tryConsumeKeywords(KeywordAs) {
 		// After AS the token can only be an alias name, so even reserved
 		// keywords are accepted (e.g. `FROM t AS from`).
-		alias, err := p.parseIdentAnyKeyword()
+		alias, err := p.parseAnyKeyword()
 		if err != nil {
 			return nil, err
 		}
@@ -831,7 +831,7 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 		// canParseWindowNameInParens already disambiguated keyword tokens
 		// (e.g. `OVER (order)` vs `OVER (ORDER BY ...)`).
 		var err error
-		windowName, err = p.parseIdentAnyKeyword()
+		windowName, err = p.parseAnyKeyword()
 		if err != nil {
 			return nil, err
 		}
@@ -863,10 +863,10 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 }
 
 func (p *Parser) canParseWindowNameInParens() bool {
-	if p.lastTokenKind() != TokenKindIdent && p.lastTokenKind() != TokenKindKeyword {
+	if !p.matchTokenKindIn(classIdent | classKeyword) {
 		return false
 	}
-	if p.lastTokenKind() != TokenKindKeyword {
+	if !p.matchTokenKindIn(classKeyword) {
 		return true
 	}
 
@@ -899,7 +899,7 @@ func (p *Parser) parseWindowClause(pos Pos) (*WindowClause, error) {
 	for {
 		// After WINDOW (or a comma) the token can only be a window name, so
 		// even reserved keywords are accepted (e.g. `WINDOW order AS (...)`).
-		windowName, err := p.parseIdentAnyKeyword()
+		windowName, err := p.parseAnyKeyword()
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parser_query.go
+++ b/parser/parser_query.go
@@ -399,7 +399,9 @@ func (p *Parser) parseTableExpr(pos Pos) (*TableExpr, error) {
 
 	tableEnd := expr.End()
 	if p.tryConsumeKeywords(KeywordAs) {
-		alias, err := p.parseIdent()
+		// After AS the token can only be an alias name, so even reserved
+		// keywords are accepted (e.g. `FROM t AS from`).
+		alias, err := p.parseIdentAnyKeyword()
 		if err != nil {
 			return nil, err
 		}
@@ -826,8 +828,10 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 	}
 	var windowName *Ident
 	if p.canParseWindowNameInParens() {
+		// canParseWindowNameInParens already disambiguated keyword tokens
+		// (e.g. `OVER (order)` vs `OVER (ORDER BY ...)`).
 		var err error
-		windowName, err = p.parseIdent()
+		windowName, err = p.parseIdentAnyKeyword()
 		if err != nil {
 			return nil, err
 		}
@@ -859,10 +863,10 @@ func (p *Parser) parseWindowCondition(pos Pos) (*WindowExpr, error) {
 }
 
 func (p *Parser) canParseWindowNameInParens() bool {
-	if !p.matchTokenKind(TokenKindIdent) {
+	if p.lastTokenKind() != TokenKindIdent && p.lastTokenKind() != TokenKindKeyword {
 		return false
 	}
-	if !p.matchTokenKind(TokenKindKeyword) {
+	if p.lastTokenKind() != TokenKindKeyword {
 		return true
 	}
 
@@ -893,7 +897,9 @@ func (p *Parser) parseWindowClause(pos Pos) (*WindowClause, error) {
 
 	windows := make([]*WindowDefinition, 0, 1)
 	for {
-		windowName, err := p.parseIdent()
+		// After WINDOW (or a comma) the token can only be a window name, so
+		// even reserved keywords are accepted (e.g. `WINDOW order AS (...)`).
+		windowName, err := p.parseIdentAnyKeyword()
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -428,7 +428,7 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		if p.tryConsumeKeywords(KeywordOver) {
 			var overExpr Expr
 			switch {
-			case p.matchTokenKindIn(classIdent | classKeyword):
+			case p.matchTokenKind(TokenKindIdent, TokenKindKeyword):
 				// After OVER a bare token can only be a window name, so even
 				// reserved keywords are accepted (e.g. `OVER order`),
 				// mirroring the WINDOW clause definition side.
@@ -454,7 +454,7 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		return funcExpr, nil
 	case p.tryConsumeTokenKind(TokenKindDot) != nil:
 		switch {
-		case p.matchTokenKindIn(classIdent | classKeyword):
+		case p.matchTokenKind(TokenKindIdent, TokenKindKeyword):
 			fields := []*Ident{ident}
 			for {
 				// After a dot the token can only be a member name, so even

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -428,8 +428,11 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		if p.tryConsumeKeywords(KeywordOver) {
 			var overExpr Expr
 			switch {
-			case p.matchTokenKind(TokenKindIdent):
-				overExpr, err = p.parseIdent()
+			case p.matchTokenKind(TokenKindIdent), p.lastTokenKind() == TokenKindKeyword:
+				// After OVER a bare token can only be a window name, so even
+				// reserved keywords are accepted (e.g. `OVER order`),
+				// mirroring the WINDOW clause definition side.
+				overExpr, err = p.parseIdentAnyKeyword()
 			case p.matchTokenKind(TokenKindLParen):
 				overExpr, err = p.parseWindowCondition(p.Pos())
 				if err != nil {

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -451,10 +451,12 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		return funcExpr, nil
 	case p.tryConsumeTokenKind(TokenKindDot) != nil:
 		switch {
-		case p.matchTokenKind(TokenKindIdent):
+		case p.matchTokenKind(TokenKindIdent), p.lastTokenKind() == TokenKindKeyword:
 			fields := []*Ident{ident}
 			for {
-				child, err := p.parseIdent()
+				// After a dot the token can only be a member name, so even
+				// reserved keywords are accepted (e.g. `t.from`).
+				child, err := p.parseIdentAnyKeyword()
 				if err != nil {
 					return nil, err
 				}

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -428,11 +428,11 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		if p.tryConsumeKeywords(KeywordOver) {
 			var overExpr Expr
 			switch {
-			case p.matchTokenKind(TokenKindIdent), p.lastTokenKind() == TokenKindKeyword:
+			case p.matchTokenKindIn(classIdent | classKeyword):
 				// After OVER a bare token can only be a window name, so even
 				// reserved keywords are accepted (e.g. `OVER order`),
 				// mirroring the WINDOW clause definition side.
-				overExpr, err = p.parseIdentAnyKeyword()
+				overExpr, err = p.parseAnyKeyword()
 			case p.matchTokenKind(TokenKindLParen):
 				overExpr, err = p.parseWindowCondition(p.Pos())
 				if err != nil {
@@ -454,12 +454,12 @@ func (p *Parser) parseIdentOrFunction(_ Pos) (Expr, error) {
 		return funcExpr, nil
 	case p.tryConsumeTokenKind(TokenKindDot) != nil:
 		switch {
-		case p.matchTokenKind(TokenKindIdent), p.lastTokenKind() == TokenKindKeyword:
+		case p.matchTokenKindIn(classIdent | classKeyword):
 			fields := []*Ident{ident}
 			for {
 				// After a dot the token can only be a member name, so even
 				// reserved keywords are accepted (e.g. `t.from`).
-				child, err := p.parseIdentAnyKeyword()
+				child, err := p.parseAnyKeyword()
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
## Summary

`matchTokenKind` previously coerced **every** keyword token to match `TokenKindIdent`, so any keyword could silently fill an identifier slot. A missing name before a clause keyword then swallowed the keyword instead of erroring:

| Input | Before | After |
|---|---|---|
| `SELECT a FROM WHERE b = 1` | parsed as `SELECT a AS FROM WHERE b = 1` | error at `WHERE`: expected table name |
| `SELECT a, b FROM GROUP BY a` | parsed as `SELECT a, b AS FROM GROUP BY a` | error at `GROUP`: expected table name |
| `INSERT INTO SELECT 1` | `SELECT` eaten as table name, confusing error at `1` | error at `SELECT` |
| `SELECT a FROM t JOIN ON a = b` | `ON` eaten as table name, confusing error at `=` | error at `ON` |

This over-acceptance is the root of the recurring keyword-as-identifier bug class (#268, #269, #270).

## Changes

- Add a `reservedKeywords` set (statement starters, clause starters, expression operators) in `keyword.go`; everything else stays non-reserved.
- Narrow the keyword→ident coercion in `matchTokenKind` to non-reserved keywords only.
- Add `parseIdentAnyKeyword` for positions where context proves even a reserved keyword is a name, and use it at those sites:
  - after `AS` (select-item and table aliases — `SELECT 2 AS from` still works)
  - after a dot in qualified names (`db.from`, `t.from`)
  - the lookahead-disambiguated select items from #269 (`SELECT a, limit FROM t`, `SELECT case;`)
  - query parameters (`{end:UInt32}`)
  - window names (`OVER (order)`, `WINDOW order AS (...)`)
  - GRANT options (`WITH GRANT OPTION`)
  - gated function names (select-item modifiers `EXCEPT/APPLY/REPLACE`, `INSERT INTO FUNCTION`)
- Bare (no-AS) select-item aliases now only accept non-reserved keywords, fixing the silent mis-parses above.

Keywords that double as ClickHouse function or engine names (`IF`, `LEFT`, `RIGHT`, `ANY`, `MIN`, `MAX`, `TRIM`, `SET`, `JOIN`, ...) are intentionally non-reserved, so `if(a, 1, 2)`, `any(b)`, `left(c, 1)` and `ENGINE = Join(...)` keep parsing.

## Testing

- New `keyword_test.go` with regression tests for rejected mis-parses, non-reserved keywords as identifiers, and reserved keywords in disambiguated positions, plus a consistency check that `reservedKeywords ⊆ keywords`.
- Full suite passes including `-race -compatible` (stateful corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)