### PR TITLE
Fix number lexing, unterminated block comments and non-ASCII bytes

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -132,15 +132,19 @@ func (l *Lexer) consumeNumber() error {
 	hasExp := false
 	hasDot := false
 	tokenKind := TokenKindInt
+	// hasNumberPart is only set when a digit is actually consumed, so that a
+	// bare prefix followed by a non-digit ("0x;") is rejected rather than
+	// lexed as an empty hex literal
 	hasNumberPart := false
 	for l.peekOk(i) {
-		hasNumberPart = true
 		c := l.peekN(i)
 		switch {
 		case base == 10 && IsDigit(c):
+			hasNumberPart = true
 			i++
 			continue
 		case base == 16 && IsHexDigit(c):
+			hasNumberPart = true
 			i++
 			continue
 		case c == '.': // float

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -124,12 +124,13 @@ func (l *Lexer) consumeNumber() error {
 		// skip sign
 		i++
 	}
-	if l.peekN(0) == '0' && l.peekOk(1) && l.peekN(1) == 'x' {
+	if l.peekOk(i+1) && l.peekN(i) == '0' && l.peekN(i+1) == 'x' {
 		i += 2
 		base = 16
 	}
 
 	hasExp := false
+	hasDot := false
 	tokenKind := TokenKindInt
 	hasNumberPart := false
 	for l.peekOk(i) {
@@ -143,10 +144,16 @@ func (l *Lexer) consumeNumber() error {
 			i++
 			continue
 		case c == '.': // float
+			// a second dot ("1.2.3"), a dot after the exponent ("1e2.3") or
+			// a dot in a hex literal ("0x1.8") cannot start a valid number tail
+			if hasDot || hasExp || base == 16 {
+				return errors.New("invalid number")
+			}
+			hasDot = true
 			tokenKind = TokenKindFloat
 			i++
 			continue
-		case base != 16 && (c == 'e' || c == 'E' || c == 'p' || c == 'P'):
+		case base != 16 && (c == 'e' || c == 'E'):
 			if hasExp {
 				return errors.New("invalid number")
 			}
@@ -158,6 +165,8 @@ func (l *Lexer) consumeNumber() error {
 				return errors.New("exponent part should contain at least one digit")
 			}
 			hasExp = true
+			// scientific notation always denotes a floating-point value
+			tokenKind = TokenKindFloat
 			continue
 		}
 		break
@@ -231,20 +240,25 @@ func (l *Lexer) consumeSingleLineComment() {
 	for l.peekOk(i) && l.peekN(i) != '\r' && l.peekN(i) != '\n' {
 		i++
 	}
-	l.skipN(i + 1)
+	if l.peekOk(i) {
+		// consume the newline too; at EOF there is none to consume
+		i++
+	}
+	l.skipN(i)
 }
 
-func (l *Lexer) consumeMultiLineComment() {
+func (l *Lexer) consumeMultiLineComment() error {
 	l.skipN(2)
 	i := 0
 	for l.peekOk(i) {
 		if l.peekOk(i+1) && l.peekN(i) == '*' && l.peekN(i+1) == '/' {
-			i += 2
-			break
+			l.skipN(i + 2)
+			return nil
 		}
 		i++
 	}
 	l.skipN(i)
+	return errors.New("unclosed multi-line comment")
 }
 
 func (l *Lexer) consumeString() error {
@@ -284,11 +298,11 @@ func (l *Lexer) consumeString() error {
 	return nil
 }
 
-func (l *Lexer) skipComments() {
+func (l *Lexer) skipComments() error {
 	for !l.isEOF() {
 		l.skipSpace()
 		if !l.peekOk(0) {
-			return
+			return nil
 		}
 		switch l.peekN(0) {
 		case '-':
@@ -296,20 +310,23 @@ func (l *Lexer) skipComments() {
 				l.consumeSingleLineComment()
 				continue
 			}
-			return
+			return nil
 		case '/': // multi-line comment
 			if l.peekOk(1) && l.peekN(1) == '*' {
-				l.consumeMultiLineComment()
+				if err := l.consumeMultiLineComment(); err != nil {
+					return err
+				}
 				continue
 			}
-			return
+			return nil
 		case '\r', '\n':
 			// skip \r\n or \n\r
 			l.skipN(1)
 		default:
-			return
+			return nil
 		}
 	}
+	return nil
 }
 
 func (l *Lexer) peekToken() (*Token, error) {
@@ -335,7 +352,9 @@ func (l *Lexer) consumeToken() error {
 	// replace the current token; keep the previous one to disambiguate unary +/-
 	prevToken := l.currentToken
 	l.currentToken = nil
-	l.skipComments()
+	if err := l.skipComments(); err != nil {
+		return err
+	}
 	l.skipSpace()
 	if l.isEOF() {
 		return nil
@@ -400,6 +419,14 @@ func (l *Lexer) consumeToken() error {
 
 	if IsIdentStart(l.peekN(0)) {
 		return l.consumeIdent(Pos(l.offset))
+	}
+
+	// Non-ASCII bytes can only appear inside quoted identifiers or string
+	// literals, which are handled above. Report the whole rune instead of
+	// emitting a one-byte token that splits the UTF-8 sequence.
+	if l.peekN(0) >= utf8.RuneSelf {
+		r, _ := utf8.DecodeRuneInString(l.input[l.offset:])
+		return fmt.Errorf("unexpected character %q", r)
 	}
 
 	token := &Token{}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -141,12 +141,6 @@ func TestConsumeNumber(t *testing.T) {
 	t.Run("Integer number", func(t *testing.T) {
 		integers := []string{
 			"123",
-			"123e+10",
-			"123e-10",
-			"123e10",
-			"123E10",
-			"123E+10",
-			"123E-10",
 		}
 		for _, i := range integers {
 			lexer := NewLexer(i)
@@ -163,6 +157,8 @@ func TestConsumeNumber(t *testing.T) {
 		numbers := []string{
 			"0x123",
 			"0x1",
+			"-0x1F",
+			"+0x1F",
 		}
 		for _, n := range numbers {
 			lexer := NewLexer(n)
@@ -186,11 +182,18 @@ func TestConsumeNumber(t *testing.T) {
 			"123E-",
 			"0x",
 			"0xg",
+			"-0x",
+			"1.2.3",
+			"1..2",
+			"1e2.3",
+			"0x1.8",
+			"1p5",
+			"1P5",
 		}
 		for _, n := range invalidNumbers {
 			lexer := NewLexer(n)
 			err := lexer.consumeToken()
-			require.Error(t, err)
+			require.Error(t, err, "input %q", n)
 		}
 	})
 
@@ -203,6 +206,13 @@ func TestConsumeNumber(t *testing.T) {
 			"123.456E10",
 			"123.456E+10",
 			"123.456E-10",
+			// scientific notation without a dot is still a float
+			"123e+10",
+			"123e-10",
+			"123e10",
+			"123E10",
+			"123E+10",
+			"123E-10",
 		}
 		for _, f := range floats {
 			lexer := NewLexer(f)
@@ -274,4 +284,64 @@ func TestConsumeNumber(t *testing.T) {
 			require.True(t, lexer.isEOF())
 		}
 	})
+}
+
+// lexAll consumes tokens until EOF or the first lexer error.
+func lexAll(input string) error {
+	lexer := NewLexer(input)
+	for !lexer.isEOF() {
+		if err := lexer.consumeToken(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestUnterminatedBlockCommentIsAnError guards that a block comment without a
+// closing */ is reported instead of being silently swallowed at EOF.
+func TestUnterminatedBlockCommentIsAnError(t *testing.T) {
+	inputs := []string{
+		"/*",
+		"/* unterminated",
+		"/* unterminated *",
+		"SELECT 1 /* unterminated",
+	}
+	for _, input := range inputs {
+		err := lexAll(input)
+		require.Error(t, err, "input %q", input)
+		require.Contains(t, err.Error(), "unclosed multi-line comment")
+	}
+	// terminated comments still parse
+	_, err := NewParser("SELECT 1 /* ok */").ParseStmts()
+	require.NoError(t, err)
+}
+
+// TestSingleLineCommentAtEOF guards that the lexer offset does not run past
+// the end of input when a -- comment has no trailing newline.
+func TestSingleLineCommentAtEOF(t *testing.T) {
+	lexer := NewLexer("-- no newline")
+	require.NoError(t, lexer.consumeToken())
+	require.True(t, lexer.isEOF())
+	require.LessOrEqual(t, lexer.offset, len(lexer.input))
+}
+
+// TestNonASCIIByteIsAnError guards that a bare multi-byte character produces
+// a readable error naming the whole rune instead of a garbage one-byte token
+// that splits the UTF-8 sequence.
+func TestNonASCIIByteIsAnError(t *testing.T) {
+	err := lexAll("SELECT 中文")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "'中'")
+
+	// quoted identifiers and string literals may still carry non-ASCII text
+	_, err = NewParser("SELECT `中文`, '中文'").ParseStmts()
+	require.NoError(t, err)
+}
+
+// TestNegativeHexLiteral guards the sign handling in consumeNumber: the 0x
+// check previously peeked at the sign instead of the first digit.
+func TestNegativeHexLiteral(t *testing.T) {
+	stmts, err := NewParser("SELECT 1 FROM t WHERE x = -0xFF").ParseStmts()
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
 }

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -183,6 +183,7 @@ func TestConsumeNumber(t *testing.T) {
 			"0x",
 			"0xg",
 			"-0x",
+			"0x;", // bare prefix followed by a non-digit is not an empty hex literal
 			"1.2.3",
 			"1..2",
 			"1e2.3",


### PR DESCRIPTION
## Summary

Four lexer-level bugs, each verified against ClickHouse behavior:

| Input | Before | After |
|---|---|---|
| `WHERE x = -0xFF` | hard parse error | lexes as hex literal `-0xFF` |
| `SELECT 1.2.3`, `SELECT 1..2` | accepted as a **single float token** | invalid number |
| `SELECT 1e2.3`, `SELECT 0x1.8`, `SELECT 1p5` | accepted | invalid number |
| `SELECT 1e5` | `TokenKindInt` | `TokenKindFloat` |
| `SELECT 1 /* unterminated` | comment silently swallowed, statement parses | `unclosed multi-line comment` error |
| `SELECT 中文` | garbage one-byte token splitting the UTF-8 rune (`unexpected token kind: �`) | `unexpected character '中'` |

## Details

- **Sign + hex prefix**: `consumeNumber` peeked at `peekN(0)`/`peekN(1)` for `0x` *after* consuming a sign, so the prefix check looked at the sign itself. It now starts at the position after the sign.
- **Dot rules**: a second dot, a dot after an exponent, and a dot inside a hex literal now fail instead of silently producing junk literals like `1.2.3` that break any downstream evaluator. Legit forms (`1.`, `.5`, `t.1.2` tuple access) are unaffected — covered by existing fixtures, no golden changed.
- **p/P exponent removed**: it only exists for hex floats (unsupported); previously `1p5` lexed as an *integer* with literal `1p5`.
- **Unterminated `/* ... `**: `consumeMultiLineComment` now returns an error, plumbed through `skipComments` → `consumeToken`. Single-line comments at EOF also no longer push the offset one byte past the input.
- **Non-ASCII bytes**: the one-byte-token fallback now rejects bytes ≥ 0x80 with the whole decoded rune in the message. Backtick identifiers and string literals still carry non-ASCII text as before.

## Note on error surfacing

Mid-statement lexer errors are still discarded by the parser's `_ = p.lexer.consumeToken()` call sites (they degrade into misleading `<eof>` errors). That's a separate parser-side fix coming in a follow-up PR; the new tests here assert at the lexer level so this PR stands alone.

No golden fixture changed — `make test` passes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)