### PR TITLE
Fix signed number after ')' or ']' being lexed as a literal

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -349,7 +349,11 @@ func (l *Lexer) hasPrecedenceToken(last *Token) bool {
 		last.Kind == TokenKindKeyword ||
 		last.Kind == TokenKindInt ||
 		last.Kind == TokenKindFloat ||
-		last.Kind == TokenKindString)
+		last.Kind == TokenKindString ||
+		// A closing bracket also terminates an expression, so a following
+		// +/- is a binary operator, e.g. (1)-1 or arr[1]-1.
+		last.Kind == TokenKindRParen ||
+		last.Kind == TokenKindRBracket)
 }
 
 func (l *Lexer) consumeToken() error {

--- a/parser/precedence_test.go
+++ b/parser/precedence_test.go
@@ -116,6 +116,24 @@ func TestNotInGroupsLikeIn(t *testing.T) {
 	}
 }
 
+func TestSignedNumberAfterClosingBracketIsBinaryOperator(t *testing.T) {
+	// A closing `)` or `]` ends an expression, so the following `+`/`-` is a
+	// binary operator and not the sign of the next numeric literal.
+	for _, sql := range []string{"SELECT (1)-1", "SELECT arr[1]-1", "SELECT f()-1"} {
+		expr := parseSelectItemExpr(t, sql)
+		op, ok := expr.(*BinaryOperation)
+		require.True(t, ok, "%s: expected BinaryOperation at the top, got %T", sql, expr)
+		require.Equal(t, TokenKindMinus, op.Operation, sql)
+		right, ok := op.RightExpr.(*NumberLiteral)
+		require.True(t, ok, "%s: right side should be the unsigned literal `1`, got %T", sql, op.RightExpr)
+		require.Equal(t, "1", right.Literal, sql)
+	}
+
+	// A `+`/`-` after an opening bracket is still a sign, not an operator.
+	expr := parseSelectItemExpr(t, "SELECT arr[-1]")
+	require.Equal(t, "arr[-1]", Format(expr))
+}
+
 func TestIntersect(t *testing.T) {
 	stmts, err := NewParser("SELECT 1 INTERSECT SELECT 2").ParseStmts()
 	require.NoError(t, err)

--- a/parser/testdata/query/format/beautify/select_signed_number_after_bracket.sql
+++ b/parser/testdata/query/format/beautify/select_signed_number_after_bracket.sql
@@ -1,0 +1,16 @@
+-- Origin SQL:
+SELECT (1)-1;
+SELECT (1)+1.5;
+SELECT arr[1]-1;
+SELECT (toUnixTimestamp(now())-3600)*1000000000;
+
+
+-- Beautify SQL:
+SELECT
+  (1) - 1;
+SELECT
+  (1) + 1.5;
+SELECT
+  arr[1] - 1;
+SELECT
+  (toUnixTimestamp(now()) - 3600) * 1000000000;

--- a/parser/testdata/query/format/select_signed_number_after_bracket.sql
+++ b/parser/testdata/query/format/select_signed_number_after_bracket.sql
@@ -1,0 +1,12 @@
+-- Origin SQL:
+SELECT (1)-1;
+SELECT (1)+1.5;
+SELECT arr[1]-1;
+SELECT (toUnixTimestamp(now())-3600)*1000000000;
+
+
+-- Format SQL:
+SELECT (1) - 1;
+SELECT (1) + 1.5;
+SELECT arr[1] - 1;
+SELECT (toUnixTimestamp(now()) - 3600) * 1000000000;

--- a/parser/testdata/query/output/select_signed_number_after_bracket.sql.golden.json
+++ b/parser/testdata/query/output/select_signed_number_after_bracket.sql.golden.json
@@ -1,0 +1,304 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 12,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftParenPos": 7,
+            "RightParenPos": 9,
+            "Items": {
+              "ListPos": 8,
+              "ListEnd": 9,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 8,
+                    "NumEnd": 9,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          },
+          "Operation": "-",
+          "RightExpr": {
+            "NumPos": 11,
+            "NumEnd": 12,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 14,
+    "StatementEnd": 28,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftParenPos": 21,
+            "RightParenPos": 23,
+            "Items": {
+              "ListPos": 22,
+              "ListEnd": 23,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 22,
+                    "NumEnd": 23,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          },
+          "Operation": "+",
+          "RightExpr": {
+            "NumPos": 25,
+            "NumEnd": 28,
+            "Literal": "1.5",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 30,
+    "StatementEnd": 45,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Object": {
+              "Name": "arr",
+              "QuoteType": 1,
+              "NamePos": 37,
+              "NameEnd": 40
+            },
+            "Params": {
+              "LeftBracketPos": 40,
+              "RightBracketPos": 42,
+              "Items": {
+                "ListPos": 41,
+                "ListEnd": 42,
+                "HasDistinct": false,
+                "Items": [
+                  {
+                    "Expr": {
+                      "NumPos": 41,
+                      "NumEnd": 42,
+                      "Literal": "1",
+                      "Base": 10
+                    },
+                    "Alias": null
+                  }
+                ]
+              }
+            }
+          },
+          "Operation": "-",
+          "RightExpr": {
+            "NumPos": 44,
+            "NumEnd": 45,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 47,
+    "StatementEnd": 94,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftParenPos": 54,
+            "RightParenPos": 82,
+            "Items": {
+              "ListPos": 55,
+              "ListEnd": 82,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "LeftExpr": {
+                      "Name": {
+                        "Name": "toUnixTimestamp",
+                        "QuoteType": 1,
+                        "NamePos": 55,
+                        "NameEnd": 70
+                      },
+                      "Params": {
+                        "LeftParenPos": 70,
+                        "RightParenPos": 76,
+                        "Items": {
+                          "ListPos": 71,
+                          "ListEnd": 75,
+                          "HasDistinct": false,
+                          "Items": [
+                            {
+                              "Expr": {
+                                "Name": {
+                                  "Name": "now",
+                                  "QuoteType": 1,
+                                  "NamePos": 71,
+                                  "NameEnd": 74
+                                },
+                                "Params": {
+                                  "LeftParenPos": 74,
+                                  "RightParenPos": 75,
+                                  "Items": {
+                                    "ListPos": 75,
+                                    "ListEnd": 75,
+                                    "HasDistinct": false,
+                                    "Items": []
+                                  },
+                                  "ColumnArgList": null
+                                }
+                              },
+                              "Alias": null
+                            }
+                          ]
+                        },
+                        "ColumnArgList": null
+                      }
+                    },
+                    "Operation": "-",
+                    "RightExpr": {
+                      "NumPos": 78,
+                      "NumEnd": 82,
+                      "Literal": "3600",
+                      "Base": 10
+                    },
+                    "HasGlobal": false,
+                    "HasNot": false
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          },
+          "Operation": "*",
+          "RightExpr": {
+            "NumPos": 84,
+            "NumEnd": 94,
+            "Literal": "1000000000",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": null,
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/select_signed_number_after_bracket.sql
+++ b/parser/testdata/query/select_signed_number_after_bracket.sql
@@ -1,0 +1,4 @@
+SELECT (1)-1;
+SELECT (1)+1.5;
+SELECT arr[1]-1;
+SELECT (toUnixTimestamp(now())-3600)*1000000000;


### PR DESCRIPTION
Fixes #286.

The lexer decides whether `+`/`-` is a sign or a binary operator by looking at the previous token, but the set of tokens that can end an expression didn't include `)` or `]`. So `SELECT (1)-1` lexed `-1` as a signed literal and the parser saw two expressions with no operator between them, rejecting SQL that ClickHouse accepts.

Added `TokenKindRParen` and `TokenKindRBracket` to that set, plus a test and a fixture covering the paren, array-index and function-call forms.

```sql
SELECT (1)-1                                     -- was: <EOF> or ';' was expected, but got: "-1"
SELECT arr[1]-1
SELECT (toUnixTimestamp(now())-3600)*1000000000  -- was: expected ')', but got '<int>'
```

`+`/`-` after an opening bracket is still treated as a sign, so `arr[-1]` is unchanged. No existing golden files changed.