### PR TITLE
Add support to understand the GCD codec

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1554,6 +1554,13 @@ func (p *Parser) tryParseCompressionLevel(pos Pos) (*NumberLiteral, error) {
 		return nil, nil // nolint
 	}
 
+	if p.matchTokenKind(TokenKindRParen) {
+		if err := p.expectTokenKind(TokenKindRParen); err != nil {
+			return nil, err
+		}
+		return nil, nil // nolint
+	}
+
 	num, err := p.parseNumber(pos)
 	if err != nil {
 		return nil, err

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1555,7 +1555,7 @@ func (p *Parser) tryParseCompressionLevel(pos Pos) (*NumberLiteral, error) {
 	}
 
 	if p.matchTokenKind(TokenKindRParen) {
-		return p.expectTokenKind(TokenKindRParen)
+		return nil, p.expectTokenKind(TokenKindRParen)
 	}
 
 	num, err := p.parseNumber(pos)

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1555,10 +1555,7 @@ func (p *Parser) tryParseCompressionLevel(pos Pos) (*NumberLiteral, error) {
 	}
 
 	if p.matchTokenKind(TokenKindRParen) {
-		if err := p.expectTokenKind(TokenKindRParen); err != nil {
-			return nil, err
-		}
-		return nil, nil // nolint
+		return p.expectTokenKind(TokenKindRParen)
 	}
 
 	num, err := p.parseNumber(pos)

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1452,7 +1452,7 @@ func (p *Parser) tryParseCompressionCodecs(pos Pos) (*CompressionCodec, error) {
 	var name *Ident
 	var typeLevel *NumberLiteral
 	switch strings.ToUpper(codecType.Name) {
-	case "DELTA", "DOUBLEDELTA", "T64", "GORILLA":
+	case "DELTA", "DOUBLEDELTA", "T64", "GORILLA", "GCD":
 		// try parse delta level
 		typeLevel, err = p.tryParseCompressionLevel(p.Pos())
 		if err != nil {

--- a/parser/testdata/ddl/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/create_table_with_codec_gcd.sql
@@ -1,7 +1,7 @@
 CREATE TABLE test_local
 (
- `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `count` UInt64 CODEC(GCD)
+ `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `bar` UInt64 CODEC(GCD)
 )
 ENGINE = MergeTree
-ORDER BY `count`;
+ORDER BY `bar`;

--- a/parser/testdata/ddl/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/create_table_with_codec_gcd.sql
@@ -1,0 +1,7 @@
+CREATE TABLE test_local
+(
+ `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `count` UInt64 CODEC(GCD)
+)
+ENGINE = MergeTree
+ORDER BY `count`;

--- a/parser/testdata/ddl/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/create_table_with_codec_gcd.sql
@@ -1,7 +1,8 @@
 CREATE TABLE test_local
 (
  `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `bar` UInt64 CODEC(GCD)
+ `bar` UInt64 CODEC(GCD),
+ `baz` Decimal(38, 4) CODEC(GCD(), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY `bar`;

--- a/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
@@ -1,19 +1,19 @@
 -- Origin SQL:
 CREATE TABLE test_local
 (
- `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `count` UInt64 CODEC(GCD)
+ `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `bar` UInt64 CODEC(GCD)
 )
 ENGINE = MergeTree
-ORDER BY `count`;
+ORDER BY `bar`;
 
 
 -- Beautify SQL:
 CREATE TABLE test_local
 (
-  `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
-  `count` UInt64 CODEC(GCD)
+  `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+  `bar` UInt64 CODEC(GCD)
 )
 ENGINE = MergeTree
 ORDER BY
-  `count`;
+  `bar`;

--- a/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
@@ -1,0 +1,19 @@
+-- Origin SQL:
+CREATE TABLE test_local
+(
+ `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `count` UInt64 CODEC(GCD)
+)
+ENGINE = MergeTree
+ORDER BY `count`;
+
+
+-- Beautify SQL:
+CREATE TABLE test_local
+(
+  `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+  `count` UInt64 CODEC(GCD)
+)
+ENGINE = MergeTree
+ORDER BY
+  `count`;

--- a/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/beautify/create_table_with_codec_gcd.sql
@@ -2,7 +2,8 @@
 CREATE TABLE test_local
 (
  `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `bar` UInt64 CODEC(GCD)
+ `bar` UInt64 CODEC(GCD),
+ `baz` Decimal(38, 4) CODEC(GCD(), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY `bar`;
@@ -12,7 +13,8 @@ ORDER BY `bar`;
 CREATE TABLE test_local
 (
   `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
-  `bar` UInt64 CODEC(GCD)
+  `bar` UInt64 CODEC(GCD),
+  `baz` Decimal(38, 4) CODEC(GCD, ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY

--- a/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
@@ -1,0 +1,12 @@
+-- Origin SQL:
+CREATE TABLE test_local
+(
+ `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `count` UInt64 CODEC(GCD)
+)
+ENGINE = MergeTree
+ORDER BY `count`;
+
+
+-- Format SQL:
+CREATE TABLE test_local (`expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)), `count` UInt64 CODEC(GCD)) ENGINE = MergeTree ORDER BY `count`;

--- a/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
@@ -2,11 +2,12 @@
 CREATE TABLE test_local
 (
  `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `bar` UInt64 CODEC(GCD)
+ `bar` UInt64 CODEC(GCD),
+ `baz` Decimal(38, 4) CODEC(GCD(), ZSTD(1))
 )
 ENGINE = MergeTree
 ORDER BY `bar`;
 
 
 -- Format SQL:
-CREATE TABLE test_local (`foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)), `bar` UInt64 CODEC(GCD)) ENGINE = MergeTree ORDER BY `bar`;
+CREATE TABLE test_local (`foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)), `bar` UInt64 CODEC(GCD), `baz` Decimal(38, 4) CODEC(GCD, ZSTD(1))) ENGINE = MergeTree ORDER BY `bar`;

--- a/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
+++ b/parser/testdata/ddl/format/create_table_with_codec_gcd.sql
@@ -1,12 +1,12 @@
 -- Origin SQL:
 CREATE TABLE test_local
 (
- `expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
- `count` UInt64 CODEC(GCD)
+ `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
+ `bar` UInt64 CODEC(GCD)
 )
 ENGINE = MergeTree
-ORDER BY `count`;
+ORDER BY `bar`;
 
 
 -- Format SQL:
-CREATE TABLE test_local (`expectedrevenue` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)), `count` UInt64 CODEC(GCD)) ENGINE = MergeTree ORDER BY `count`;
+CREATE TABLE test_local (`foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)), `bar` UInt64 CODEC(GCD)) ENGINE = MergeTree ORDER BY `bar`;

--- a/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
@@ -1,0 +1,183 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 154,
+    "OrReplace": false,
+    "Name": {
+      "Database": null,
+      "Table": {
+        "Name": "test_local",
+        "QuoteType": 1,
+        "NamePos": 13,
+        "NameEnd": 23
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "TableSchema": {
+      "SchemaPos": 24,
+      "SchemaEnd": 118,
+      "Columns": [
+        {
+          "NamePos": 28,
+          "ColumnEnd": 89,
+          "Name": {
+            "Ident": {
+              "Name": "expectedrevenue",
+              "QuoteType": 3,
+              "NamePos": 28,
+              "NameEnd": 43
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 54,
+            "RightParenPos": 68,
+            "Name": {
+              "Name": "Nullable",
+              "QuoteType": 1,
+              "NamePos": 45,
+              "NameEnd": 53
+            },
+            "Params": [
+              {
+                "LeftParenPos": 62,
+                "RightParenPos": 67,
+                "Name": {
+                  "Name": "Decimal",
+                  "QuoteType": 1,
+                  "NamePos": 54,
+                  "NameEnd": 61
+                },
+                "Params": [
+                  {
+                    "NumPos": 62,
+                    "NumEnd": 64,
+                    "Literal": "38",
+                    "Base": 10
+                  },
+                  {
+                    "NumPos": 66,
+                    "NumEnd": 67,
+                    "Literal": "4",
+                    "Base": 10
+                  }
+                ]
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": {
+            "CodecPos": 70,
+            "RightParenPos": 89,
+            "Type": {
+              "Name": "GCD",
+              "QuoteType": 1,
+              "NamePos": 76,
+              "NameEnd": 79
+            },
+            "TypeLevel": null,
+            "Name": {
+              "Name": "ZSTD",
+              "QuoteType": 1,
+              "NamePos": 81,
+              "NameEnd": 85
+            },
+            "Level": {
+              "NumPos": 85,
+              "NumEnd": 87,
+              "Literal": "1",
+              "Base": 10
+            }
+          },
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        {
+          "NamePos": 93,
+          "ColumnEnd": 117,
+          "Name": {
+            "Ident": {
+              "Name": "count",
+              "QuoteType": 3,
+              "NamePos": 93,
+              "NameEnd": 98
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt64",
+              "QuoteType": 1,
+              "NamePos": 100,
+              "NameEnd": 106
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": {
+            "CodecPos": 107,
+            "RightParenPos": 117,
+            "Type": null,
+            "TypeLevel": null,
+            "Name": {
+              "Name": "GCD",
+              "QuoteType": 1,
+              "NamePos": 113,
+              "NameEnd": 116
+            },
+            "Level": null
+          },
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        }
+      ],
+      "AliasTable": null,
+      "TableFunction": null
+    },
+    "Engine": {
+      "EnginePos": 120,
+      "EngineEnd": 154,
+      "Name": "MergeTree",
+      "Params": null,
+      "PrimaryKey": null,
+      "PartitionBy": null,
+      "SampleBy": null,
+      "TTL": null,
+      "Settings": null,
+      "OrderBy": {
+        "OrderPos": 139,
+        "ListEnd": 154,
+        "Items": [
+          {
+            "OrderPos": 139,
+            "Expr": {
+              "Name": "count",
+              "QuoteType": 3,
+              "NamePos": 149,
+              "NameEnd": 154
+            },
+            "Alias": null,
+            "Direction": "",
+            "Fill": null
+          }
+        ],
+        "Interpolate": null
+      }
+    },
+    "SubQuery": null,
+    "TableFunction": null,
+    "HasTemporary": false,
+    "Comment": null
+  }
+]

--- a/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
@@ -1,7 +1,7 @@
 [
   {
     "CreatePos": 0,
-    "StatementEnd": 138,
+    "StatementEnd": 183,
     "OrReplace": false,
     "Name": {
       "Database": null,
@@ -17,7 +17,7 @@
     "OnCluster": null,
     "TableSchema": {
       "SchemaPos": 24,
-      "SchemaEnd": 104,
+      "SchemaEnd": 149,
       "Columns": [
         {
           "NamePos": 28,
@@ -140,14 +140,82 @@
           "TTL": null,
           "Comment": null,
           "CompressionCodec": null
+        },
+        {
+          "NamePos": 107,
+          "ColumnEnd": 148,
+          "Name": {
+            "Ident": {
+              "Name": "baz",
+              "QuoteType": 3,
+              "NamePos": 107,
+              "NameEnd": 110
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "LeftParenPos": 120,
+            "RightParenPos": 125,
+            "Name": {
+              "Name": "Decimal",
+              "QuoteType": 1,
+              "NamePos": 112,
+              "NameEnd": 119
+            },
+            "Params": [
+              {
+                "NumPos": 120,
+                "NumEnd": 122,
+                "Literal": "38",
+                "Base": 10
+              },
+              {
+                "NumPos": 124,
+                "NumEnd": 125,
+                "Literal": "4",
+                "Base": 10
+              }
+            ]
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": {
+            "CodecPos": 127,
+            "RightParenPos": 148,
+            "Type": {
+              "Name": "GCD",
+              "QuoteType": 1,
+              "NamePos": 133,
+              "NameEnd": 136
+            },
+            "TypeLevel": null,
+            "Name": {
+              "Name": "ZSTD",
+              "QuoteType": 1,
+              "NamePos": 140,
+              "NameEnd": 144
+            },
+            "Level": {
+              "NumPos": 144,
+              "NumEnd": 146,
+              "Literal": "1",
+              "Base": 10
+            }
+          },
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
         }
       ],
       "AliasTable": null,
       "TableFunction": null
     },
     "Engine": {
-      "EnginePos": 106,
-      "EngineEnd": 138,
+      "EnginePos": 151,
+      "EngineEnd": 183,
       "Name": "MergeTree",
       "Params": null,
       "PrimaryKey": null,
@@ -156,16 +224,16 @@
       "TTL": null,
       "Settings": null,
       "OrderBy": {
-        "OrderPos": 125,
-        "ListEnd": 138,
+        "OrderPos": 170,
+        "ListEnd": 183,
         "Items": [
           {
-            "OrderPos": 125,
+            "OrderPos": 170,
             "Expr": {
               "Name": "bar",
               "QuoteType": 3,
-              "NamePos": 135,
-              "NameEnd": 138
+              "NamePos": 180,
+              "NameEnd": 183
             },
             "Alias": null,
             "Direction": "",

--- a/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
+++ b/parser/testdata/ddl/output/create_table_with_codec_gcd.sql.golden.json
@@ -1,7 +1,7 @@
 [
   {
     "CreatePos": 0,
-    "StatementEnd": 154,
+    "StatementEnd": 138,
     "OrReplace": false,
     "Name": {
       "Database": null,
@@ -17,49 +17,49 @@
     "OnCluster": null,
     "TableSchema": {
       "SchemaPos": 24,
-      "SchemaEnd": 118,
+      "SchemaEnd": 104,
       "Columns": [
         {
           "NamePos": 28,
-          "ColumnEnd": 89,
+          "ColumnEnd": 77,
           "Name": {
             "Ident": {
-              "Name": "expectedrevenue",
+              "Name": "foo",
               "QuoteType": 3,
               "NamePos": 28,
-              "NameEnd": 43
+              "NameEnd": 31
             },
             "DotIdent": null
           },
           "Type": {
-            "LeftParenPos": 54,
-            "RightParenPos": 68,
+            "LeftParenPos": 42,
+            "RightParenPos": 56,
             "Name": {
               "Name": "Nullable",
               "QuoteType": 1,
-              "NamePos": 45,
-              "NameEnd": 53
+              "NamePos": 33,
+              "NameEnd": 41
             },
             "Params": [
               {
-                "LeftParenPos": 62,
-                "RightParenPos": 67,
+                "LeftParenPos": 50,
+                "RightParenPos": 55,
                 "Name": {
                   "Name": "Decimal",
                   "QuoteType": 1,
-                  "NamePos": 54,
-                  "NameEnd": 61
+                  "NamePos": 42,
+                  "NameEnd": 49
                 },
                 "Params": [
                   {
-                    "NumPos": 62,
-                    "NumEnd": 64,
+                    "NumPos": 50,
+                    "NumEnd": 52,
                     "Literal": "38",
                     "Base": 10
                   },
                   {
-                    "NumPos": 66,
-                    "NumEnd": 67,
+                    "NumPos": 54,
+                    "NumEnd": 55,
                     "Literal": "4",
                     "Base": 10
                   }
@@ -73,24 +73,24 @@
           "MaterializedExpr": null,
           "AliasExpr": null,
           "Codec": {
-            "CodecPos": 70,
-            "RightParenPos": 89,
+            "CodecPos": 58,
+            "RightParenPos": 77,
             "Type": {
               "Name": "GCD",
               "QuoteType": 1,
-              "NamePos": 76,
-              "NameEnd": 79
+              "NamePos": 64,
+              "NameEnd": 67
             },
             "TypeLevel": null,
             "Name": {
               "Name": "ZSTD",
               "QuoteType": 1,
-              "NamePos": 81,
-              "NameEnd": 85
+              "NamePos": 69,
+              "NameEnd": 73
             },
             "Level": {
-              "NumPos": 85,
-              "NumEnd": 87,
+              "NumPos": 73,
+              "NumEnd": 75,
               "Literal": "1",
               "Base": 10
             }
@@ -100,14 +100,14 @@
           "CompressionCodec": null
         },
         {
-          "NamePos": 93,
-          "ColumnEnd": 117,
+          "NamePos": 81,
+          "ColumnEnd": 103,
           "Name": {
             "Ident": {
-              "Name": "count",
+              "Name": "bar",
               "QuoteType": 3,
-              "NamePos": 93,
-              "NameEnd": 98
+              "NamePos": 81,
+              "NameEnd": 84
             },
             "DotIdent": null
           },
@@ -115,8 +115,8 @@
             "Name": {
               "Name": "UInt64",
               "QuoteType": 1,
-              "NamePos": 100,
-              "NameEnd": 106
+              "NamePos": 86,
+              "NameEnd": 92
             }
           },
           "NotNull": null,
@@ -125,15 +125,15 @@
           "MaterializedExpr": null,
           "AliasExpr": null,
           "Codec": {
-            "CodecPos": 107,
-            "RightParenPos": 117,
+            "CodecPos": 93,
+            "RightParenPos": 103,
             "Type": null,
             "TypeLevel": null,
             "Name": {
               "Name": "GCD",
               "QuoteType": 1,
-              "NamePos": 113,
-              "NameEnd": 116
+              "NamePos": 99,
+              "NameEnd": 102
             },
             "Level": null
           },
@@ -146,8 +146,8 @@
       "TableFunction": null
     },
     "Engine": {
-      "EnginePos": 120,
-      "EngineEnd": 154,
+      "EnginePos": 106,
+      "EngineEnd": 138,
       "Name": "MergeTree",
       "Params": null,
       "PrimaryKey": null,
@@ -156,16 +156,16 @@
       "TTL": null,
       "Settings": null,
       "OrderBy": {
-        "OrderPos": 139,
-        "ListEnd": 154,
+        "OrderPos": 125,
+        "ListEnd": 138,
         "Items": [
           {
-            "OrderPos": 139,
+            "OrderPos": 125,
             "Expr": {
-              "Name": "count",
+              "Name": "bar",
               "QuoteType": 3,
-              "NamePos": 149,
-              "NameEnd": 154
+              "NamePos": 135,
+              "NameEnd": 138
             },
             "Alias": null,
             "Direction": "",


### PR DESCRIPTION
This PR adds the support for the GCD codec.

Previously the following would error - 

```
 `foo` Nullable(Decimal(38, 4)) CODEC(GCD, ZSTD(1)),
 `bar` UInt64 CODEC(GCD)

```
