### PR TITLE
Fix parsing of operator expressions in table function arguments

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -275,12 +275,21 @@ func (p *Parser) parseSubExpr(pos Pos, precedence int) (Expr, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return p.parseInfixLoop(expr, precedence)
+}
+
+// parseInfixLoop folds binary operators into expr while the next operator
+// binds tighter than precedence; it stops at once on tokens that are no
+// operator at all, such as ',' or ')'.
+func (p *Parser) parseInfixLoop(expr Expr, precedence int) (Expr, error) {
 	for !p.lexer.isEOF() {
 		nextPrecedence := p.getNextPrecedence()
 		if nextPrecedence <= precedence {
 			return expr, nil
 		}
 		// parse binary operation
+		var err error
 		expr, err = p.parseInfix(expr, nextPrecedence)
 		if err != nil {
 			return nil, err

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -746,6 +746,15 @@ func (p *Parser) parseTableColumnExpr(pos Pos) (*ColumnDef, error) {
 }
 
 func (p *Parser) parseTableArgExpr(pos Pos) (Expr, error) {
+	expr, err := p.parseTableArgPrimaryExpr(pos)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.parseInfixLoop(expr, PrecedenceUnknown)
+}
+
+func (p *Parser) parseTableArgPrimaryExpr(pos Pos) (Expr, error) {
 	switch {
 	case p.matchTokenKind(TokenKindIdent):
 		ident, err := p.parseIdent()
@@ -777,7 +786,8 @@ func (p *Parser) parseTableArgExpr(pos Pos) (Expr, error) {
 		}
 	case p.matchTokenKind(TokenKindLParen):
 		return p.parseSubQuery(p.Pos())
-	case p.matchTokenKind(TokenKindInt), p.matchTokenKind(TokenKindString), p.matchKeyword(KeywordNull):
+	case p.matchTokenKind(TokenKindInt), p.matchTokenKind(TokenKindFloat),
+		p.matchTokenKind(TokenKindString), p.matchKeyword(KeywordNull):
 		return p.parseLiteral(p.Pos())
 	default:
 		return nil, fmt.Errorf("unexpected token: %q, expected <Name>, <literal>", p.currentTokenString())
@@ -790,7 +800,7 @@ func (p *Parser) parseTableArgList(pos Pos) (*TableArgListExpr, error) {
 	}
 
 	args := make([]Expr, 0)
-	for !p.lexer.isEOF() {
+	for !p.lexer.isEOF() && !p.matchTokenKind(TokenKindRParen) {
 		// Check if this is a named parameter (identifier followed by =)
 		var arg Expr
 		var err error

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -785,7 +785,14 @@ func (p *Parser) parseTableArgPrimaryExpr(pos Pos) (Expr, error) {
 			return ident, nil
 		}
 	case p.matchTokenKind(TokenKindLParen):
-		return p.parseSubQuery(p.Pos())
+		// a leading '(' opens a subquery only when SELECT or WITH follows,
+		// e.g. remote('127.0.0.1', (SELECT 1)); anything else is a
+		// parenthesized expression, e.g. numbers((1 + 1))
+		if p.peekKeyword(KeywordSelect) || p.peekKeyword(KeywordWith) {
+			return p.parseSubQuery(p.Pos())
+		}
+
+		return p.parseFunctionParams(p.Pos())
 	case p.matchTokenKind(TokenKindInt), p.matchTokenKind(TokenKindFloat),
 		p.matchTokenKind(TokenKindString), p.matchKeyword(KeywordNull):
 		return p.parseLiteral(p.Pos())

--- a/parser/precedence_test.go
+++ b/parser/precedence_test.go
@@ -399,6 +399,69 @@ func TestGlobalInAndGlobalNotIn(t *testing.T) {
 	}
 }
 
+// parseTableFunctionExpr parses a single-statement SELECT and returns the
+// table function in its FROM clause.
+func parseTableFunctionExpr(t *testing.T, sql string) *TableFunctionExpr {
+	t.Helper()
+	from := parseOneStmt(t, sql).(*SelectQuery).From.Expr
+	table, ok := from.(*JoinTableExpr)
+	require.True(t, ok, "%s: expected *JoinTableExpr in FROM, got %T", sql, from)
+	fn, ok := table.Table.Expr.(*TableFunctionExpr)
+	require.True(t, ok, "%s: expected *TableFunctionExpr, got %T", sql, table.Table.Expr)
+	return fn
+}
+
+func TestTableFunctionArgAcceptsOperatorExpressions(t *testing.T) {
+	// a table-function argument continues into the operator loop, so the
+	// argument is the whole `1 + 1`, not just the first literal
+	fn := parseTableFunctionExpr(t, "SELECT * FROM numbers(1 + 1)")
+	require.Len(t, fn.Args.Args, 1)
+	op, ok := fn.Args.Args[0].(*BinaryOperation)
+	require.True(t, ok, "argument should be the binary operation `1 + 1`, got %T", fn.Args.Args[0])
+	require.Equal(t, TokenKindPlus, op.Operation)
+
+	// a nested call keeps its *TableFunctionExpr shape as the left operand
+	fn = parseTableFunctionExpr(t, "SELECT * FROM numbers(intDiv(a, b) + 1)")
+	op, ok = fn.Args.Args[0].(*BinaryOperation)
+	require.True(t, ok, "argument should be a binary operation, got %T", fn.Args.Args[0])
+	_, ok = op.LeftExpr.(*TableFunctionExpr)
+	require.True(t, ok, "left operand should stay a *TableFunctionExpr, got %T", op.LeftExpr)
+
+	for _, sql := range []string{
+		"SELECT * FROM numbers(greatest(1, a - b))",
+		"SELECT * FROM cluster('c', numbers(1 + 1))",
+		"SELECT * FROM numbers(x AND y)",
+	} {
+		require.Equal(t, sql, Format(parseOneStmt(t, sql)), sql)
+	}
+}
+
+func TestTableFunctionArgFloatAndZeroArgumentCall(t *testing.T) {
+	fn := parseTableFunctionExpr(t, "SELECT * FROM numbers(1.5)")
+	num, ok := fn.Args.Args[0].(*NumberLiteral)
+	require.True(t, ok, "argument should be a *NumberLiteral, got %T", fn.Args.Args[0])
+	require.Equal(t, "1.5", num.Literal)
+
+	fn = parseTableFunctionExpr(t, "SELECT * FROM numbers(now())")
+	nested, ok := fn.Args.Args[0].(*TableFunctionExpr)
+	require.True(t, ok, "argument should be the zero-argument call, got %T", fn.Args.Args[0])
+	require.Empty(t, nested.Args.Args)
+}
+
+func TestTableFunctionArgShapesUnchanged(t *testing.T) {
+	// a signed literal is still one literal, not a unary operation
+	fn := parseTableFunctionExpr(t, "SELECT * FROM numbers(-1)")
+	num, ok := fn.Args.Args[0].(*NumberLiteral)
+	require.True(t, ok, "argument should stay the signed literal `-1`, got %T", fn.Args.Args[0])
+	require.Equal(t, "-1", num.Literal)
+
+	// a qualified name is still a *NestedIdentifier, not an IndexOperation
+	fn = parseTableFunctionExpr(t, "SELECT * FROM cluster('c', db.table)")
+	require.Len(t, fn.Args.Args, 2)
+	_, ok = fn.Args.Args[1].(*NestedIdentifier)
+	require.True(t, ok, "second argument should stay a *NestedIdentifier, got %T", fn.Args.Args[1])
+}
+
 func TestGlobalInGroupsLikeIn(t *testing.T) {
 	// GLOBAL IN binds like IN: `a = b GLOBAL IN (1)` is `a = (b GLOBAL IN (1))`
 	for _, sql := range []string{"SELECT a = b GLOBAL IN (1)", "SELECT a = b GLOBAL NOT IN (1)"} {

--- a/parser/precedence_test.go
+++ b/parser/precedence_test.go
@@ -448,6 +448,27 @@ func TestTableFunctionArgFloatAndZeroArgumentCall(t *testing.T) {
 	require.Empty(t, nested.Args.Args)
 }
 
+func TestTableFunctionArgParenthesizedExpression(t *testing.T) {
+	// a leading '(' that does not open a subquery is a parenthesized
+	// expression, with the shape the scalar `SELECT (1 + 1)` produces
+	fn := parseTableFunctionExpr(t, "SELECT * FROM numbers((1 + 1))")
+	params, ok := fn.Args.Args[0].(*ParamExprList)
+	require.True(t, ok, "argument should be a *ParamExprList, got %T", fn.Args.Args[0])
+	require.Len(t, params.Items.Items, 1)
+	item, ok := params.Items.Items[0].(*ColumnExpr)
+	require.True(t, ok, "parenthesized item should be a *ColumnExpr, got %T", params.Items.Items[0])
+	_, ok = item.Expr.(*BinaryOperation)
+	require.True(t, ok, "parenthesized argument should hold `1 + 1`, got %T", item.Expr)
+
+	sql := "SELECT * FROM numbers((a + b) * c)"
+	require.Equal(t, sql, Format(parseOneStmt(t, sql)))
+
+	// a '(' that opens a subquery still parses as one
+	fn = parseTableFunctionExpr(t, "SELECT * FROM remote('127.0.0.1', (SELECT 1))")
+	_, ok = fn.Args.Args[1].(*SubQuery)
+	require.True(t, ok, "second argument should stay a *SubQuery, got %T", fn.Args.Args[1])
+}
+
 func TestTableFunctionArgShapesUnchanged(t *testing.T) {
 	// a signed literal is still one literal, not a unary operation
 	fn := parseTableFunctionExpr(t, "SELECT * FROM numbers(-1)")

--- a/parser/testdata/query/format/beautify/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/format/beautify/select_table_function_arg_exprs.sql
@@ -6,6 +6,10 @@ SELECT * FROM cluster('c', numbers(1 + 1));
 SELECT * FROM numbers(x AND y);
 SELECT * FROM numbers(1.5);
 SELECT * FROM numbers(now());
+SELECT * FROM numbers((1 + 1));
+SELECT * FROM numbers((a + b) * c);
+SELECT * FROM numbers((1));
+SELECT * FROM remote('127.0.0.1', (SELECT 1));
 
 
 -- Beautify SQL:
@@ -39,3 +43,20 @@ SELECT
   *
 FROM
   numbers(now());
+SELECT
+  *
+FROM
+  numbers((1 + 1));
+SELECT
+  *
+FROM
+  numbers((a + b) * c);
+SELECT
+  *
+FROM
+  numbers((1));
+SELECT
+  *
+FROM
+  remote('127.0.0.1', (SELECT
+    1));

--- a/parser/testdata/query/format/beautify/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/format/beautify/select_table_function_arg_exprs.sql
@@ -1,0 +1,41 @@
+-- Origin SQL:
+SELECT * FROM numbers(1 + 1);
+SELECT * FROM numbers(intDiv(a, b) + 1);
+SELECT * FROM numbers(greatest(1, a - b));
+SELECT * FROM cluster('c', numbers(1 + 1));
+SELECT * FROM numbers(x AND y);
+SELECT * FROM numbers(1.5);
+SELECT * FROM numbers(now());
+
+
+-- Beautify SQL:
+SELECT
+  *
+FROM
+  numbers(1 + 1);
+SELECT
+  *
+FROM
+  numbers(intDiv(a, b) + 1);
+SELECT
+  *
+FROM
+  numbers(greatest(1, a - b));
+SELECT
+  *
+FROM
+  cluster('c', numbers(1 + 1));
+SELECT
+  *
+FROM
+  numbers(x
+  AND
+    y);
+SELECT
+  *
+FROM
+  numbers(1.5);
+SELECT
+  *
+FROM
+  numbers(now());

--- a/parser/testdata/query/format/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/format/select_table_function_arg_exprs.sql
@@ -1,0 +1,18 @@
+-- Origin SQL:
+SELECT * FROM numbers(1 + 1);
+SELECT * FROM numbers(intDiv(a, b) + 1);
+SELECT * FROM numbers(greatest(1, a - b));
+SELECT * FROM cluster('c', numbers(1 + 1));
+SELECT * FROM numbers(x AND y);
+SELECT * FROM numbers(1.5);
+SELECT * FROM numbers(now());
+
+
+-- Format SQL:
+SELECT * FROM numbers(1 + 1);
+SELECT * FROM numbers(intDiv(a, b) + 1);
+SELECT * FROM numbers(greatest(1, a - b));
+SELECT * FROM cluster('c', numbers(1 + 1));
+SELECT * FROM numbers(x AND y);
+SELECT * FROM numbers(1.5);
+SELECT * FROM numbers(now());

--- a/parser/testdata/query/format/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/format/select_table_function_arg_exprs.sql
@@ -6,6 +6,10 @@ SELECT * FROM cluster('c', numbers(1 + 1));
 SELECT * FROM numbers(x AND y);
 SELECT * FROM numbers(1.5);
 SELECT * FROM numbers(now());
+SELECT * FROM numbers((1 + 1));
+SELECT * FROM numbers((a + b) * c);
+SELECT * FROM numbers((1));
+SELECT * FROM remote('127.0.0.1', (SELECT 1));
 
 
 -- Format SQL:
@@ -16,3 +20,7 @@ SELECT * FROM cluster('c', numbers(1 + 1));
 SELECT * FROM numbers(x AND y);
 SELECT * FROM numbers(1.5);
 SELECT * FROM numbers(now());
+SELECT * FROM numbers((1 + 1));
+SELECT * FROM numbers((a + b) * c);
+SELECT * FROM numbers((1));
+SELECT * FROM remote('127.0.0.1', (SELECT 1));

--- a/parser/testdata/query/output/select_table_function_arg_exprs.sql.golden.json
+++ b/parser/testdata/query/output/select_table_function_arg_exprs.sql.golden.json
@@ -1,0 +1,606 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 27,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 7,
+          "NameEnd": 7
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 9,
+      "Expr": {
+        "Table": {
+          "TablePos": 14,
+          "TableEnd": 27,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 14,
+              "NameEnd": 21
+            },
+            "Args": {
+              "LeftParenPos": 21,
+              "RightParenPos": 27,
+              "Args": [
+                {
+                  "LeftExpr": {
+                    "NumPos": 22,
+                    "NumEnd": 23,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "Operation": "+",
+                  "RightExpr": {
+                    "NumPos": 26,
+                    "NumEnd": 27,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "HasGlobal": false,
+                  "HasNot": false
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 27,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 30,
+    "StatementEnd": 68,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 37,
+          "NameEnd": 37
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 39,
+      "Expr": {
+        "Table": {
+          "TablePos": 44,
+          "TableEnd": 68,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 44,
+              "NameEnd": 51
+            },
+            "Args": {
+              "LeftParenPos": 51,
+              "RightParenPos": 68,
+              "Args": [
+                {
+                  "LeftExpr": {
+                    "Name": {
+                      "Name": "intDiv",
+                      "QuoteType": 1,
+                      "NamePos": 52,
+                      "NameEnd": 58
+                    },
+                    "Args": {
+                      "LeftParenPos": 52,
+                      "RightParenPos": 63,
+                      "Args": [
+                        {
+                          "Name": "a",
+                          "QuoteType": 1,
+                          "NamePos": 59,
+                          "NameEnd": 60
+                        },
+                        {
+                          "Name": "b",
+                          "QuoteType": 1,
+                          "NamePos": 62,
+                          "NameEnd": 63
+                        }
+                      ]
+                    }
+                  },
+                  "Operation": "+",
+                  "RightExpr": {
+                    "NumPos": 67,
+                    "NumEnd": 68,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "HasGlobal": false,
+                  "HasNot": false
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 68,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 71,
+    "StatementEnd": 111,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 78,
+          "NameEnd": 78
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 80,
+      "Expr": {
+        "Table": {
+          "TablePos": 85,
+          "TableEnd": 111,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 85,
+              "NameEnd": 92
+            },
+            "Args": {
+              "LeftParenPos": 92,
+              "RightParenPos": 111,
+              "Args": [
+                {
+                  "Name": {
+                    "Name": "greatest",
+                    "QuoteType": 1,
+                    "NamePos": 93,
+                    "NameEnd": 101
+                  },
+                  "Args": {
+                    "LeftParenPos": 93,
+                    "RightParenPos": 110,
+                    "Args": [
+                      {
+                        "NumPos": 102,
+                        "NumEnd": 103,
+                        "Literal": "1",
+                        "Base": 10
+                      },
+                      {
+                        "LeftExpr": {
+                          "Name": "a",
+                          "QuoteType": 1,
+                          "NamePos": 105,
+                          "NameEnd": 106
+                        },
+                        "Operation": "-",
+                        "RightExpr": {
+                          "Name": "b",
+                          "QuoteType": 1,
+                          "NamePos": 109,
+                          "NameEnd": 110
+                        },
+                        "HasGlobal": false,
+                        "HasNot": false
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 111,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 114,
+    "StatementEnd": 155,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 121,
+          "NameEnd": 121
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 123,
+      "Expr": {
+        "Table": {
+          "TablePos": 128,
+          "TableEnd": 155,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "cluster",
+              "QuoteType": 1,
+              "NamePos": 128,
+              "NameEnd": 135
+            },
+            "Args": {
+              "LeftParenPos": 135,
+              "RightParenPos": 155,
+              "Args": [
+                {
+                  "LiteralPos": 137,
+                  "LiteralEnd": 138,
+                  "Literal": "c"
+                },
+                {
+                  "Name": {
+                    "Name": "numbers",
+                    "QuoteType": 1,
+                    "NamePos": 141,
+                    "NameEnd": 148
+                  },
+                  "Args": {
+                    "LeftParenPos": 141,
+                    "RightParenPos": 154,
+                    "Args": [
+                      {
+                        "LeftExpr": {
+                          "NumPos": 149,
+                          "NumEnd": 150,
+                          "Literal": "1",
+                          "Base": 10
+                        },
+                        "Operation": "+",
+                        "RightExpr": {
+                          "NumPos": 153,
+                          "NumEnd": 154,
+                          "Literal": "1",
+                          "Base": 10
+                        },
+                        "HasGlobal": false,
+                        "HasNot": false
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 155,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 158,
+    "StatementEnd": 187,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 165,
+          "NameEnd": 165
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 167,
+      "Expr": {
+        "Table": {
+          "TablePos": 172,
+          "TableEnd": 187,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 172,
+              "NameEnd": 179
+            },
+            "Args": {
+              "LeftParenPos": 179,
+              "RightParenPos": 187,
+              "Args": [
+                {
+                  "LeftExpr": {
+                    "Name": "x",
+                    "QuoteType": 1,
+                    "NamePos": 180,
+                    "NameEnd": 181
+                  },
+                  "Operation": "AND",
+                  "RightExpr": {
+                    "Name": "y",
+                    "QuoteType": 1,
+                    "NamePos": 186,
+                    "NameEnd": 187
+                  },
+                  "HasGlobal": false,
+                  "HasNot": false
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 187,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 190,
+    "StatementEnd": 215,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 197,
+          "NameEnd": 197
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 199,
+      "Expr": {
+        "Table": {
+          "TablePos": 204,
+          "TableEnd": 215,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 204,
+              "NameEnd": 211
+            },
+            "Args": {
+              "LeftParenPos": 211,
+              "RightParenPos": 215,
+              "Args": [
+                {
+                  "NumPos": 212,
+                  "NumEnd": 215,
+                  "Literal": "1.5",
+                  "Base": 10
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 215,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 218,
+    "StatementEnd": 245,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 225,
+          "NameEnd": 225
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 227,
+      "Expr": {
+        "Table": {
+          "TablePos": 232,
+          "TableEnd": 245,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 232,
+              "NameEnd": 239
+            },
+            "Args": {
+              "LeftParenPos": 239,
+              "RightParenPos": 245,
+              "Args": [
+                {
+                  "Name": {
+                    "Name": "now",
+                    "QuoteType": 1,
+                    "NamePos": 240,
+                    "NameEnd": 243
+                  },
+                  "Args": {
+                    "LeftParenPos": 240,
+                    "RightParenPos": 244,
+                    "Args": []
+                  }
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 245,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_table_function_arg_exprs.sql.golden.json
+++ b/parser/testdata/query/output/select_table_function_arg_exprs.sql.golden.json
@@ -602,5 +602,397 @@
     "UnionDistinct": null,
     "Except": null,
     "Intersect": null
+  },
+  {
+    "SelectPos": 248,
+    "StatementEnd": 277,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 255,
+          "NameEnd": 255
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 257,
+      "Expr": {
+        "Table": {
+          "TablePos": 262,
+          "TableEnd": 277,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 262,
+              "NameEnd": 269
+            },
+            "Args": {
+              "LeftParenPos": 269,
+              "RightParenPos": 277,
+              "Args": [
+                {
+                  "LeftParenPos": 270,
+                  "RightParenPos": 276,
+                  "Items": {
+                    "ListPos": 271,
+                    "ListEnd": 276,
+                    "HasDistinct": false,
+                    "Items": [
+                      {
+                        "Expr": {
+                          "LeftExpr": {
+                            "NumPos": 271,
+                            "NumEnd": 272,
+                            "Literal": "1",
+                            "Base": 10
+                          },
+                          "Operation": "+",
+                          "RightExpr": {
+                            "NumPos": 275,
+                            "NumEnd": 276,
+                            "Literal": "1",
+                            "Base": 10
+                          },
+                          "HasGlobal": false,
+                          "HasNot": false
+                        },
+                        "Alias": null
+                      }
+                    ]
+                  },
+                  "ColumnArgList": null
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 277,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 280,
+    "StatementEnd": 313,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 287,
+          "NameEnd": 287
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 289,
+      "Expr": {
+        "Table": {
+          "TablePos": 294,
+          "TableEnd": 313,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 294,
+              "NameEnd": 301
+            },
+            "Args": {
+              "LeftParenPos": 301,
+              "RightParenPos": 313,
+              "Args": [
+                {
+                  "LeftExpr": {
+                    "LeftParenPos": 302,
+                    "RightParenPos": 308,
+                    "Items": {
+                      "ListPos": 303,
+                      "ListEnd": 308,
+                      "HasDistinct": false,
+                      "Items": [
+                        {
+                          "Expr": {
+                            "LeftExpr": {
+                              "Name": "a",
+                              "QuoteType": 1,
+                              "NamePos": 303,
+                              "NameEnd": 304
+                            },
+                            "Operation": "+",
+                            "RightExpr": {
+                              "Name": "b",
+                              "QuoteType": 1,
+                              "NamePos": 307,
+                              "NameEnd": 308
+                            },
+                            "HasGlobal": false,
+                            "HasNot": false
+                          },
+                          "Alias": null
+                        }
+                      ]
+                    },
+                    "ColumnArgList": null
+                  },
+                  "Operation": "*",
+                  "RightExpr": {
+                    "Name": "c",
+                    "QuoteType": 1,
+                    "NamePos": 312,
+                    "NameEnd": 313
+                  },
+                  "HasGlobal": false,
+                  "HasNot": false
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 313,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 316,
+    "StatementEnd": 341,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 323,
+          "NameEnd": 323
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 325,
+      "Expr": {
+        "Table": {
+          "TablePos": 330,
+          "TableEnd": 341,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "numbers",
+              "QuoteType": 1,
+              "NamePos": 330,
+              "NameEnd": 337
+            },
+            "Args": {
+              "LeftParenPos": 337,
+              "RightParenPos": 341,
+              "Args": [
+                {
+                  "LeftParenPos": 338,
+                  "RightParenPos": 340,
+                  "Items": {
+                    "ListPos": 339,
+                    "ListEnd": 340,
+                    "HasDistinct": false,
+                    "Items": [
+                      {
+                        "Expr": {
+                          "NumPos": 339,
+                          "NumEnd": 340,
+                          "Literal": "1",
+                          "Base": 10
+                        },
+                        "Alias": null
+                      }
+                    ]
+                  },
+                  "ColumnArgList": null
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 341,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  },
+  {
+    "SelectPos": 344,
+    "StatementEnd": 388,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "*",
+          "QuoteType": 0,
+          "NamePos": 351,
+          "NameEnd": 351
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 353,
+      "Expr": {
+        "Table": {
+          "TablePos": 358,
+          "TableEnd": 388,
+          "Alias": null,
+          "Expr": {
+            "Name": {
+              "Name": "remote",
+              "QuoteType": 1,
+              "NamePos": 358,
+              "NameEnd": 364
+            },
+            "Args": {
+              "LeftParenPos": 364,
+              "RightParenPos": 388,
+              "Args": [
+                {
+                  "LiteralPos": 366,
+                  "LiteralEnd": 375,
+                  "Literal": "127.0.0.1"
+                },
+                {
+                  "HasParen": true,
+                  "Select": {
+                    "SelectPos": 379,
+                    "StatementEnd": 387,
+                    "With": null,
+                    "Top": null,
+                    "HasDistinct": false,
+                    "DistinctOn": null,
+                    "SelectItems": [
+                      {
+                        "Expr": {
+                          "NumPos": 386,
+                          "NumEnd": 387,
+                          "Literal": "1",
+                          "Base": 10
+                        },
+                        "Modifiers": [],
+                        "Alias": null
+                      }
+                    ],
+                    "From": null,
+                    "Window": null,
+                    "Prewhere": null,
+                    "Where": null,
+                    "GroupBy": null,
+                    "WithTotal": false,
+                    "Having": null,
+                    "OrderBy": null,
+                    "LimitBy": null,
+                    "Limit": null,
+                    "Settings": null,
+                    "Format": null,
+                    "UnionAll": null,
+                    "UnionDistinct": null,
+                    "Except": null,
+                    "Intersect": null
+                  }
+                }
+              ]
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 388,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
   }
 ]

--- a/parser/testdata/query/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/select_table_function_arg_exprs.sql
@@ -1,0 +1,7 @@
+SELECT * FROM numbers(1 + 1);
+SELECT * FROM numbers(intDiv(a, b) + 1);
+SELECT * FROM numbers(greatest(1, a - b));
+SELECT * FROM cluster('c', numbers(1 + 1));
+SELECT * FROM numbers(x AND y);
+SELECT * FROM numbers(1.5);
+SELECT * FROM numbers(now());

--- a/parser/testdata/query/select_table_function_arg_exprs.sql
+++ b/parser/testdata/query/select_table_function_arg_exprs.sql
@@ -5,3 +5,7 @@ SELECT * FROM cluster('c', numbers(1 + 1));
 SELECT * FROM numbers(x AND y);
 SELECT * FROM numbers(1.5);
 SELECT * FROM numbers(now());
+SELECT * FROM numbers((1 + 1));
+SELECT * FROM numbers((a + b) * c);
+SELECT * FROM numbers((1));
+SELECT * FROM remote('127.0.0.1', (SELECT 1));


### PR DESCRIPTION
Fixes #297.

`parseTableArgExpr` stopped after a single primary (identifier, nested call, subquery or literal), so any operator, float literal or zero-argument call inside a FROM-position table-function argument was rejected. Now the primary continues into the binary-operator loop shared with `parseSubExpr` (extracted as `parseInfixLoop`), the literal case accepts floats, and `parseTableArgList` returns an empty list on an immediate `)`.

All of these parse now:

```sql
SELECT * FROM numbers(1 + 1);
SELECT * FROM numbers(intDiv(a, b) + 1);
SELECT * FROM numbers(greatest(1, a - b));
SELECT * FROM cluster('c', numbers(1 + 1));
SELECT * FROM numbers(x AND y);
SELECT * FROM numbers(1.5);
SELECT * FROM numbers(now());
```

Existing argument shapes are unchanged (`numbers(-1)` stays one signed literal, `cluster('c', db.table)` stays a `NestedIdentifier`) because the operator loop stops immediately at `,` and `)` — no existing golden file changed; the goldens for the new fixture `parser/testdata/query/select_table_function_arg_exprs.sql` are the only additions, plus AST-shape tests in `precedence_test.go`. Every fixture line was verified against clickhouse-local 26.8.1: none returns a syntax error (Code 62), only semantic ones (43/47/701).
