### PR TITLE
Derive the CLI version from build info instead of a constant

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.version export-subst

--- a/.version
+++ b/.version
@@ -1,0 +1,1 @@
+$Format:%(describe:tags)$

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ all: $(PROGRAM)
 
 .PHONY: all
 
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null)
+
 $(PROGRAM):
-	go build -o $(PROGRAM) main.go
+	go build -ldflags "-X main.version=$(VERSION)" -o $(PROGRAM) .
 
 test:
 	@go test -v ./... -covermode=atomic -coverprofile=coverage.out -race -compatible

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,21 @@ ENDCOLOR="\033[0m"
 
 all: $(PROGRAM)
 
-.PHONY: all
+# The binary target is phony so a new commit, tag or VERSION override
+# always refreshes the stamped version; the Go build cache keeps the
+# rebuild cheap.
+.PHONY: all $(PROGRAM)
 
-VERSION=$(shell git describe --tags --always --dirty 2>/dev/null)
+# VERSION is stamped into the binary. Priority: a caller-supplied
+# VERSION=..., git describe in a checkout, then the git-archive
+# substitution kept in .version for builds from source archives that
+# have no Git metadata.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null)
+ifeq ($(VERSION),)
+# Reject the raw placeholder that an archive made by git older than
+# 2.35 leaves behind; the binary then falls back to Go build info.
+VERSION := $(shell grep -vE '[$$%]' .version 2>/dev/null)
+endif
 
 $(PROGRAM):
 	go build -ldflags "-X main.version=$(VERSION)" -o $(PROGRAM) .

--- a/main.go
+++ b/main.go
@@ -5,15 +5,54 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	clickhouse "github.com/AfterShip/clickhouse-sql-parser/parser"
 )
 
-const VERSION = "0.5.4"
+// version is overridable at build time via
+// -ldflags "-X main.version=..." (see the Makefile); when empty the
+// binary reports the module version the Go toolchain recorded, so a
+// `go install ...@vX.Y.Z` build needs no hand-maintained constant.
+var version string
+
 const help = `
 Usage: clickhouse-sql-parser [YOUR SQL STRING] -f [YOUR SQL FILE] -format -beautify
 `
+
+func getVersion() string {
+	if version != "" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	// A build from a source checkout has no module version; report the
+	// VCS revision the toolchain stamped instead.
+	var revision, dirty string
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			if setting.Value == "true" {
+				dirty = "-dirty"
+			}
+		}
+	}
+	if revision == "" {
+		return "devel"
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	return "devel-" + revision + dirty
+}
 
 var options struct {
 	help     bool
@@ -34,7 +73,7 @@ func init() {
 func main() {
 	flag.Parse()
 	if options.version {
-		fmt.Println("v" + VERSION)
+		fmt.Println(getVersion())
 		os.Exit(0)
 	}
 	if len(os.Args) < 2 || options.help {


### PR DESCRIPTION
The VERSION constant in main.go had to be bumped by hand on every
release and was regularly forgotten: the CLI reported v0.4.17 for
every release up to v0.5.3 (#219, #299).

The binary now asks the Go toolchain for its version instead. A
go install ...@vX.Y.Z build reports the module version recorded in
build info, so tagging a release is the only step left. A build
from a source checkout falls back to the stamped VCS revision,
reported as devel-<sha> with a -dirty suffix when modified. The
Makefile passes git describe output via -ldflags as an override so
make-built binaries report the nearest tag, and it now builds the
package path instead of main.go so build info stays embedded.

Requested by git-hulk in #299.

Assistant By Claude Fable 5