### PR TITLE
Fix should allow END as a bare column name

### DIFF
--- a/parser/keyword.go
+++ b/parser/keyword.go
@@ -273,7 +273,9 @@ const (
 // name, or a lookahead-disambiguated select item — use parseAnyKeyword.
 //
 // Keywords that double as ClickHouse function or engine names (IF, LEFT,
-// RIGHT, ANY, MIN, MAX, TRIM, SET, JOIN...) must stay non-reserved.
+// RIGHT, ANY, MIN, MAX, TRIM, SET, JOIN...) must stay non-reserved. So must
+// END: it only ever appears as a CASE terminator, which parseColumnCaseExpr
+// expects explicitly, and ClickHouse accepts `end` as a column name.
 var reservedKeywords = NewSet(
 	KeywordAlter,
 	KeywordAnd,
@@ -287,7 +289,6 @@ var reservedKeywords = NewSet(
 	KeywordDistinct,
 	KeywordDrop,
 	KeywordElse,
-	KeywordEnd,
 	KeywordExcept,
 	KeywordExplain,
 	KeywordFormat,

--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -45,11 +45,32 @@ func TestNonReservedKeywordAsIdentifier(t *testing.T) {
 		"SELECT t.key FROM t",
 		"SELECT if(a, 1, 2), any(b), left(c, 1) FROM t",
 		"SELECT * FROM t WHERE key = 1",
+		"SELECT max(end) FROM t",
+		"SELECT * FROM t WHERE end > start",
+		"INSERT INTO t (end) VALUES (1)",
+		"CREATE TABLE t (end DateTime) ENGINE=Memory",
+		"SELECT CASE WHEN end > start THEN end ELSE start END FROM t",
 	}
 	for _, sql := range cases {
 		t.Run(sql, func(t *testing.T) {
 			_, err := NewParser(sql).ParseStmts()
 			require.NoError(t, err)
+		})
+	}
+}
+
+// TestCaseExprRequiresEnd asserts that END, which is non-reserved so that
+// columns can be named `end`, still terminates a CASE expression: a CASE
+// without it must fail instead of running into the next clause.
+func TestCaseExprRequiresEnd(t *testing.T) {
+	cases := []string{
+		"SELECT CASE WHEN a THEN 1 ELSE 2 FROM t",
+		"SELECT CASE WHEN a THEN 1 FROM t",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.Error(t, err)
 		})
 	}
 }

--- a/parser/testdata/query/format/beautify/select_end_as_column_name.sql
+++ b/parser/testdata/query/format/beautify/select_end_as_column_name.sql
@@ -1,0 +1,23 @@
+-- Origin SQL:
+SELECT max(end), CASE WHEN end > start THEN 1 ELSE 0 END AS active
+FROM t
+WHERE end > start
+GROUP BY end
+ORDER BY end
+
+
+-- Beautify SQL:
+SELECT
+  max(end),
+  CASE
+    WHEN end > start THEN 1
+    ELSE 0
+  END AS active
+FROM
+  t
+WHERE
+  end > start
+GROUP BY
+  end
+ORDER BY
+  end;

--- a/parser/testdata/query/format/select_end_as_column_name.sql
+++ b/parser/testdata/query/format/select_end_as_column_name.sql
@@ -1,0 +1,10 @@
+-- Origin SQL:
+SELECT max(end), CASE WHEN end > start THEN 1 ELSE 0 END AS active
+FROM t
+WHERE end > start
+GROUP BY end
+ORDER BY end
+
+
+-- Format SQL:
+SELECT max(end), CASE WHEN end > start THEN 1 ELSE 0 END AS active FROM t WHERE end > start GROUP BY end ORDER BY end;

--- a/parser/testdata/query/output/select_end_as_column_name.sql.golden.json
+++ b/parser/testdata/query/output/select_end_as_column_name.sql.golden.json
@@ -1,0 +1,195 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 117,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": {
+            "Name": "max",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 10
+          },
+          "Params": {
+            "LeftParenPos": 10,
+            "RightParenPos": 14,
+            "Items": {
+              "ListPos": 11,
+              "ListEnd": 14,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": "end",
+                    "QuoteType": 1,
+                    "NamePos": 11,
+                    "NameEnd": 14
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "CasePos": 17,
+          "EndPos": 0,
+          "Expr": null,
+          "Whens": [
+            {
+              "WhenPos": 22,
+              "ThenPos": 39,
+              "When": {
+                "LeftExpr": {
+                  "Name": "end",
+                  "QuoteType": 1,
+                  "NamePos": 27,
+                  "NameEnd": 30
+                },
+                "Operation": "\u003e",
+                "RightExpr": {
+                  "Name": "start",
+                  "QuoteType": 1,
+                  "NamePos": 33,
+                  "NameEnd": 38
+                },
+                "HasGlobal": false,
+                "HasNot": false
+              },
+              "Then": {
+                "NumPos": 44,
+                "NumEnd": 45,
+                "Literal": "1",
+                "Base": 10
+              },
+              "ElsePos": 0,
+              "Else": null
+            }
+          ],
+          "ElsePos": 46,
+          "Else": {
+            "NumPos": 51,
+            "NumEnd": 52,
+            "Literal": "0",
+            "Base": 10
+          }
+        },
+        "Modifiers": [],
+        "Alias": {
+          "Name": "active",
+          "QuoteType": 1,
+          "NamePos": 60,
+          "NameEnd": 66
+        }
+      }
+    ],
+    "From": {
+      "FromPos": 67,
+      "Expr": {
+        "Table": {
+          "TablePos": 72,
+          "TableEnd": 73,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "t",
+              "QuoteType": 1,
+              "NamePos": 72,
+              "NameEnd": 73
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 73,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 74,
+      "Expr": {
+        "LeftExpr": {
+          "Name": "end",
+          "QuoteType": 1,
+          "NamePos": 80,
+          "NameEnd": 83
+        },
+        "Operation": "\u003e",
+        "RightExpr": {
+          "Name": "start",
+          "QuoteType": 1,
+          "NamePos": 86,
+          "NameEnd": 91
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": {
+      "GroupByPos": 92,
+      "GroupByEnd": 104,
+      "AggregateType": "",
+      "Expr": {
+        "ListPos": 101,
+        "ListEnd": 104,
+        "HasDistinct": false,
+        "Items": [
+          {
+            "Expr": {
+              "Name": "end",
+              "QuoteType": 1,
+              "NamePos": 101,
+              "NameEnd": 104
+            },
+            "Alias": null
+          }
+        ]
+      },
+      "WithCube": false,
+      "WithRollup": false,
+      "WithTotals": false
+    },
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": {
+      "OrderPos": 105,
+      "ListEnd": 117,
+      "Items": [
+        {
+          "OrderPos": 105,
+          "Expr": {
+            "Name": "end",
+            "QuoteType": 1,
+            "NamePos": 114,
+            "NameEnd": 117
+          },
+          "Alias": null,
+          "Direction": "",
+          "Fill": null
+        }
+      ],
+      "Interpolate": null
+    },
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/select_end_as_column_name.sql
+++ b/parser/testdata/query/select_end_as_column_name.sql
@@ -1,0 +1,5 @@
+SELECT max(end), CASE WHEN end > start THEN 1 ELSE 0 END AS active
+FROM t
+WHERE end > start
+GROUP BY end
+ORDER BY end


### PR DESCRIPTION
Make `END` non-reserved again so columns named `end` parse, since ClickHouse does not reserve it.

`END` joined `reservedKeywords` in #282, which broke `end` as a bare column name everywhere except the few lookahead-disambiguated positions:

- `SELECT max(end) FROM t` (function arguments)
- `SELECT * FROM t WHERE end > start` (expressions)
- `INSERT INTO t (end) VALUES (1)`
- `CREATE TABLE t (end DateTime) ENGINE=Memory`

`SELECT end FROM t`, `GROUP BY end` and `ORDER BY end` already worked, which made the breakage look partial.

CASE is unaffected: `parseColumnCaseExpr` expects the `END` keyword explicitly, so `CASE WHEN a THEN 1 ELSE 2 FROM t` still errors (covered by a new test) — same as ClickHouse, which reports a syntax error for it.

All of the above statements were verified against `clickhouse local` 26.7.1 (Docker `clickhouse/clickhouse-server:latest`).

Tests: cases added to `TestNonReservedKeywordAsIdentifier`, new `TestCaseExprRequiresEnd`, and fixture `parser/testdata/query/select_end_as_column_name.sql` with regenerated goldens.