### PR TITLE
Fix parsing of HTTP dictionary sources

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -4387,7 +4387,13 @@ func (d *DictionarySourceClause) Accept(visitor ASTVisitor) error {
 type DictionaryArgExpr struct {
 	ArgPos Pos
 	Name   *Ident
-	Value  Expr // can be Ident with optional parentheses or literal
+	Value  Expr // can be Ident with optional parentheses or literal, nil for a nested argument list
+	// Args holds a nested argument list such as CREDENTIALS(USER 'u' PASSWORD 'p').
+	Args []*DictionaryArgExpr
+	// LParenPos tells a nested list apart from a value: it is only set when the
+	// argument is written with parentheses, which may hold no argument at all.
+	LParenPos Pos
+	RParenPos Pos
 }
 
 func (d *DictionaryArgExpr) Pos() Pos {
@@ -4395,7 +4401,14 @@ func (d *DictionaryArgExpr) Pos() Pos {
 }
 
 func (d *DictionaryArgExpr) End() Pos {
-	return d.Value.End()
+	if d.Value != nil {
+		return d.Value.End()
+	}
+	return d.RParenPos + 1
+}
+
+func (d *DictionaryArgExpr) hasArgList() bool {
+	return d.LParenPos != 0
 }
 
 func (d *DictionaryArgExpr) Accept(visitor ASTVisitor) error {
@@ -4404,8 +4417,15 @@ func (d *DictionaryArgExpr) Accept(visitor ASTVisitor) error {
 	if err := d.Name.Accept(visitor); err != nil {
 		return err
 	}
-	if err := d.Value.Accept(visitor); err != nil {
-		return err
+	if d.Value != nil {
+		if err := d.Value.Accept(visitor); err != nil {
+			return err
+		}
+	}
+	for _, arg := range d.Args {
+		if err := arg.Accept(visitor); err != nil {
+			return err
+		}
 	}
 	return visitor.VisitDictionaryArgExpr(d)
 }

--- a/parser/format.go
+++ b/parser/format.go
@@ -1219,8 +1219,19 @@ func (d *DestinationClause) FormatSQL(formatter *Formatter) {
 
 func (d *DictionaryArgExpr) FormatSQL(formatter *Formatter) {
 	formatter.WriteExpr(d.Name)
-	formatter.WriteByte(whitespace)
-	formatter.WriteExpr(d.Value)
+	if !d.hasArgList() {
+		formatter.WriteByte(whitespace)
+		formatter.WriteExpr(d.Value)
+		return
+	}
+	formatter.WriteByte('(')
+	for i, arg := range d.Args {
+		if i > 0 {
+			formatter.WriteByte(whitespace)
+		}
+		formatter.WriteExpr(arg)
+	}
+	formatter.WriteByte(')')
 }
 
 func (d *DictionaryAttribute) FormatSQL(formatter *Formatter) {

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -2259,19 +2259,9 @@ func (p *Parser) parseDictionarySourceClause(pos Pos) (*DictionarySourceClause, 
 		return nil, err
 	}
 
-	var args []*DictionaryArgExpr
-	// Parse optional arguments
-	for !p.matchTokenKind(TokenKindRParen) {
-		arg, err := p.parseDictionaryArgExpr(p.Pos())
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, arg)
-
-		// If there's no right paren, we expect another arg (no comma needed)
-		if p.matchTokenKind(TokenKindRParen) {
-			break
-		}
+	args, err := p.parseDictionaryArgExprs()
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.expectTokenKind(TokenKindRParen); err != nil {
@@ -2291,10 +2281,52 @@ func (p *Parser) parseDictionarySourceClause(pos Pos) (*DictionarySourceClause, 
 	}, nil
 }
 
+// parseDictionaryArgExprs parses the arguments of a dictionary clause, which
+// are separated by spaces instead of commas. It stops at the closing
+// parenthesis and leaves it for the caller to consume.
+func (p *Parser) parseDictionaryArgExprs() ([]*DictionaryArgExpr, error) {
+	var args []*DictionaryArgExpr
+	for !p.matchTokenKind(TokenKindRParen) {
+		arg, err := p.parseDictionaryArgExpr(p.Pos())
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+	return args, nil
+}
+
 func (p *Parser) parseDictionaryArgExpr(pos Pos) (*DictionaryArgExpr, error) {
-	name, err := p.parseIdent()
+	// Argument names come from the source configuration, so they may be any
+	// keyword, as in SOURCE(HTTP(URL 'http://host/f.csv' FORMAT 'CSV')).
+	name, err := p.parseAnyKeyword()
 	if err != nil {
 		return nil, err
+	}
+
+	// An argument may hold its own list of arguments, as in
+	// HEADERS(HEADER(NAME 'API-KEY' VALUE 'key')).
+	if p.matchTokenKind(TokenKindLParen) {
+		lParenPos := p.Pos()
+		_ = p.lexer.consumeToken()
+
+		args, err := p.parseDictionaryArgExprs()
+		if err != nil {
+			return nil, err
+		}
+
+		rParenPos := p.Pos()
+		if err := p.expectTokenKind(TokenKindRParen); err != nil {
+			return nil, err
+		}
+
+		return &DictionaryArgExpr{
+			ArgPos:    pos,
+			Name:      name,
+			Args:      args,
+			LParenPos: lParenPos,
+			RParenPos: rParenPos,
+		}, nil
 	}
 
 	var value Expr
@@ -2422,19 +2454,9 @@ func (p *Parser) parseDictionaryLayoutClause(pos Pos) (*DictionaryLayoutClause, 
 		return nil, err
 	}
 
-	var args []*DictionaryArgExpr
-	// Parse optional arguments
-	for !p.matchTokenKind(TokenKindRParen) {
-		arg, err := p.parseDictionaryArgExpr(p.Pos())
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, arg)
-
-		// If there's no right paren, we expect another arg (no comma needed)
-		if p.matchTokenKind(TokenKindRParen) {
-			break
-		}
+	args, err := p.parseDictionaryArgExprs()
+	if err != nil {
+		return nil, err
 	}
 
 	if err := p.expectTokenKind(TokenKindRParen); err != nil {

--- a/parser/testdata/ddl/create_dictionary_http_source.sql
+++ b/parser/testdata/ddl/create_dictionary_http_source.sql
@@ -1,0 +1,16 @@
+CREATE DICTIONARY asns (asn UInt32, name String)
+PRIMARY KEY asn
+SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+
+CREATE DICTIONARY os (id UInt32, name String)
+PRIMARY KEY id
+SOURCE(HTTP(
+    url 'http://[::1]/os.tsv'
+    format 'TabSeparated'
+    credentials(user 'user' password 'password')
+    headers(header(name 'API-KEY' value 'key'))
+))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());

--- a/parser/testdata/ddl/format/beautify/create_dictionary_http_source.sql
+++ b/parser/testdata/ddl/format/beautify/create_dictionary_http_source.sql
@@ -1,0 +1,38 @@
+-- Origin SQL:
+CREATE DICTIONARY asns (asn UInt32, name String)
+PRIMARY KEY asn
+SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+
+CREATE DICTIONARY os (id UInt32, name String)
+PRIMARY KEY id
+SOURCE(HTTP(
+    url 'http://[::1]/os.tsv'
+    format 'TabSeparated'
+    credentials(user 'user' password 'password')
+    headers(header(name 'API-KEY' value 'key'))
+))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+
+
+-- Beautify SQL:
+CREATE DICTIONARY asns
+(
+  asn UInt32,
+  name String
+)
+PRIMARY KEY asn
+SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+CREATE DICTIONARY os
+(
+  id UInt32,
+  name String
+)
+PRIMARY KEY id
+SOURCE(HTTP(url 'http://[::1]/os.tsv' format 'TabSeparated' credentials(user 'user' password 'password') headers(header(name 'API-KEY' value 'key'))))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());

--- a/parser/testdata/ddl/format/create_dictionary_http_source.sql
+++ b/parser/testdata/ddl/format/create_dictionary_http_source.sql
@@ -1,0 +1,22 @@
+-- Origin SQL:
+CREATE DICTIONARY asns (asn UInt32, name String)
+PRIMARY KEY asn
+SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames'))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+
+CREATE DICTIONARY os (id UInt32, name String)
+PRIMARY KEY id
+SOURCE(HTTP(
+    url 'http://[::1]/os.tsv'
+    format 'TabSeparated'
+    credentials(user 'user' password 'password')
+    headers(header(name 'API-KEY' value 'key'))
+))
+LIFETIME(MIN 0 MAX 3600)
+LAYOUT(HASHED());
+
+
+-- Format SQL:
+CREATE DICTIONARY asns (asn UInt32, name String) PRIMARY KEY asn SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames')) LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED());
+CREATE DICTIONARY os (id UInt32, name String) PRIMARY KEY id SOURCE(HTTP(url 'http://[::1]/os.tsv' format 'TabSeparated' credentials(user 'user' password 'password') headers(header(name 'API-KEY' value 'key')))) LIFETIME(MIN 0 MAX 3600) LAYOUT(HASHED());

--- a/parser/testdata/ddl/output/create_dictionary_basic.sql.golden.json
+++ b/parser/testdata/ddl/output/create_dictionary_basic.sql.golden.json
@@ -239,7 +239,10 @@
               "LiteralPos": 269,
               "LiteralEnd": 278,
               "Literal": "localhost"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 284,
@@ -254,7 +257,10 @@
               "NumEnd": 293,
               "Literal": "3306",
               "Base": 10
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 298,
@@ -268,7 +274,10 @@
               "LiteralPos": 304,
               "LiteralEnd": 311,
               "Literal": "default"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 317,
@@ -282,7 +291,10 @@
               "LiteralPos": 327,
               "LiteralEnd": 327,
               "Literal": ""
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 333,
@@ -296,7 +308,10 @@
               "LiteralPos": 337,
               "LiteralEnd": 341,
               "Literal": "test"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 347,
@@ -310,7 +325,10 @@
               "LiteralPos": 354,
               "LiteralEnd": 364,
               "Literal": "dict_table"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           }
         ],
         "RParenPos": 367

--- a/parser/testdata/ddl/output/create_dictionary_comprehensive.sql.golden.json
+++ b/parser/testdata/ddl/output/create_dictionary_comprehensive.sql.golden.json
@@ -253,7 +253,10 @@
               "LiteralPos": 366,
               "LiteralEnd": 375,
               "Literal": "localhost"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 381,
@@ -268,7 +271,10 @@
               "NumEnd": 390,
               "Literal": "3306",
               "Base": 10
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 395,
@@ -282,7 +288,10 @@
               "LiteralPos": 401,
               "LiteralEnd": 405,
               "Literal": "root"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 411,
@@ -296,7 +305,10 @@
               "LiteralPos": 421,
               "LiteralEnd": 427,
               "Literal": "secret"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 433,
@@ -310,7 +322,10 @@
               "LiteralPos": 437,
               "LiteralEnd": 444,
               "Literal": "test_db"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 450,
@@ -324,7 +339,10 @@
               "LiteralPos": 457,
               "LiteralEnd": 473,
               "Literal": "dictionary_table"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           }
         ],
         "RParenPos": 476

--- a/parser/testdata/ddl/output/create_dictionary_http_source.sql.golden.json
+++ b/parser/testdata/ddl/output/create_dictionary_http_source.sql.golden.json
@@ -1,0 +1,450 @@
+[
+  {
+    "CreatePos": 0,
+    "StatementEnd": 166,
+    "OrReplace": false,
+    "Name": {
+      "Database": null,
+      "Table": {
+        "Name": "asns",
+        "QuoteType": 1,
+        "NamePos": 18,
+        "NameEnd": 22
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "Schema": {
+      "SchemaPos": 23,
+      "Attributes": [
+        {
+          "NamePos": 24,
+          "AttrEnd": 34,
+          "Name": {
+            "Name": "asn",
+            "QuoteType": 1,
+            "NamePos": 24,
+            "NameEnd": 27
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt32",
+              "QuoteType": 1,
+              "NamePos": 28,
+              "NameEnd": 34
+            }
+          },
+          "Default": null,
+          "Expression": null,
+          "Hierarchical": false,
+          "Injective": false,
+          "IsObjectId": false
+        },
+        {
+          "NamePos": 36,
+          "AttrEnd": 47,
+          "Name": {
+            "Name": "name",
+            "QuoteType": 1,
+            "NamePos": 36,
+            "NameEnd": 40
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 41,
+              "NameEnd": 47
+            }
+          },
+          "Default": null,
+          "Expression": null,
+          "Hierarchical": false,
+          "Injective": false,
+          "IsObjectId": false
+        }
+      ],
+      "RParenPos": 47
+    },
+    "Engine": {
+      "EnginePos": 49,
+      "PrimaryKey": {
+        "PrimaryKeyPos": 49,
+        "Keys": {
+          "ListPos": 61,
+          "ListEnd": 64,
+          "HasDistinct": false,
+          "Items": [
+            {
+              "Expr": {
+                "Name": "asn",
+                "QuoteType": 1,
+                "NamePos": 61,
+                "NameEnd": 64
+              },
+              "Alias": null
+            }
+          ]
+        },
+        "RParenPos": 63
+      },
+      "Source": {
+        "SourcePos": 65,
+        "Source": {
+          "Name": "HTTP",
+          "QuoteType": 1,
+          "NamePos": 72,
+          "NameEnd": 76
+        },
+        "Args": [
+          {
+            "ArgPos": 77,
+            "Name": {
+              "Name": "URL",
+              "QuoteType": 1,
+              "NamePos": 77,
+              "NameEnd": 80
+            },
+            "Value": {
+              "LiteralPos": 82,
+              "LiteralEnd": 99,
+              "Literal": "http://o/asns.csv"
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
+          },
+          {
+            "ArgPos": 101,
+            "Name": {
+              "Name": "FORMAT",
+              "QuoteType": 1,
+              "NamePos": 101,
+              "NameEnd": 107
+            },
+            "Value": {
+              "LiteralPos": 109,
+              "LiteralEnd": 121,
+              "Literal": "CSVWithNames"
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
+          }
+        ],
+        "RParenPos": 123
+      },
+      "Lifetime": {
+        "LifetimePos": 125,
+        "Min": {
+          "NumPos": 138,
+          "NumEnd": 139,
+          "Literal": "0",
+          "Base": 10
+        },
+        "Max": {
+          "NumPos": 144,
+          "NumEnd": 148,
+          "Literal": "3600",
+          "Base": 10
+        },
+        "Value": null,
+        "RParenPos": 148
+      },
+      "Layout": {
+        "LayoutPos": 150,
+        "Layout": {
+          "Name": "HASHED",
+          "QuoteType": 1,
+          "NamePos": 157,
+          "NameEnd": 163
+        },
+        "Args": null,
+        "RParenPos": 165
+      },
+      "Range": null,
+      "Settings": null
+    },
+    "Comment": null
+  },
+  {
+    "CreatePos": 169,
+    "StatementEnd": 440,
+    "OrReplace": false,
+    "Name": {
+      "Database": null,
+      "Table": {
+        "Name": "os",
+        "QuoteType": 1,
+        "NamePos": 187,
+        "NameEnd": 189
+      }
+    },
+    "IfNotExists": false,
+    "UUID": null,
+    "OnCluster": null,
+    "Schema": {
+      "SchemaPos": 190,
+      "Attributes": [
+        {
+          "NamePos": 191,
+          "AttrEnd": 200,
+          "Name": {
+            "Name": "id",
+            "QuoteType": 1,
+            "NamePos": 191,
+            "NameEnd": 193
+          },
+          "Type": {
+            "Name": {
+              "Name": "UInt32",
+              "QuoteType": 1,
+              "NamePos": 194,
+              "NameEnd": 200
+            }
+          },
+          "Default": null,
+          "Expression": null,
+          "Hierarchical": false,
+          "Injective": false,
+          "IsObjectId": false
+        },
+        {
+          "NamePos": 202,
+          "AttrEnd": 213,
+          "Name": {
+            "Name": "name",
+            "QuoteType": 1,
+            "NamePos": 202,
+            "NameEnd": 206
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 207,
+              "NameEnd": 213
+            }
+          },
+          "Default": null,
+          "Expression": null,
+          "Hierarchical": false,
+          "Injective": false,
+          "IsObjectId": false
+        }
+      ],
+      "RParenPos": 213
+    },
+    "Engine": {
+      "EnginePos": 215,
+      "PrimaryKey": {
+        "PrimaryKeyPos": 215,
+        "Keys": {
+          "ListPos": 227,
+          "ListEnd": 229,
+          "HasDistinct": false,
+          "Items": [
+            {
+              "Expr": {
+                "Name": "id",
+                "QuoteType": 1,
+                "NamePos": 227,
+                "NameEnd": 229
+              },
+              "Alias": null
+            }
+          ]
+        },
+        "RParenPos": 228
+      },
+      "Source": {
+        "SourcePos": 230,
+        "Source": {
+          "Name": "HTTP",
+          "QuoteType": 1,
+          "NamePos": 237,
+          "NameEnd": 241
+        },
+        "Args": [
+          {
+            "ArgPos": 247,
+            "Name": {
+              "Name": "url",
+              "QuoteType": 1,
+              "NamePos": 247,
+              "NameEnd": 250
+            },
+            "Value": {
+              "LiteralPos": 252,
+              "LiteralEnd": 271,
+              "Literal": "http://[::1]/os.tsv"
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
+          },
+          {
+            "ArgPos": 277,
+            "Name": {
+              "Name": "format",
+              "QuoteType": 1,
+              "NamePos": 277,
+              "NameEnd": 283
+            },
+            "Value": {
+              "LiteralPos": 285,
+              "LiteralEnd": 297,
+              "Literal": "TabSeparated"
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
+          },
+          {
+            "ArgPos": 303,
+            "Name": {
+              "Name": "credentials",
+              "QuoteType": 1,
+              "NamePos": 303,
+              "NameEnd": 314
+            },
+            "Value": null,
+            "Args": [
+              {
+                "ArgPos": 315,
+                "Name": {
+                  "Name": "user",
+                  "QuoteType": 1,
+                  "NamePos": 315,
+                  "NameEnd": 319
+                },
+                "Value": {
+                  "LiteralPos": 321,
+                  "LiteralEnd": 325,
+                  "Literal": "user"
+                },
+                "Args": null,
+                "LParenPos": 0,
+                "RParenPos": 0
+              },
+              {
+                "ArgPos": 327,
+                "Name": {
+                  "Name": "password",
+                  "QuoteType": 1,
+                  "NamePos": 327,
+                  "NameEnd": 335
+                },
+                "Value": {
+                  "LiteralPos": 337,
+                  "LiteralEnd": 345,
+                  "Literal": "password"
+                },
+                "Args": null,
+                "LParenPos": 0,
+                "RParenPos": 0
+              }
+            ],
+            "LParenPos": 314,
+            "RParenPos": 346
+          },
+          {
+            "ArgPos": 352,
+            "Name": {
+              "Name": "headers",
+              "QuoteType": 1,
+              "NamePos": 352,
+              "NameEnd": 359
+            },
+            "Value": null,
+            "Args": [
+              {
+                "ArgPos": 360,
+                "Name": {
+                  "Name": "header",
+                  "QuoteType": 1,
+                  "NamePos": 360,
+                  "NameEnd": 366
+                },
+                "Value": null,
+                "Args": [
+                  {
+                    "ArgPos": 367,
+                    "Name": {
+                      "Name": "name",
+                      "QuoteType": 1,
+                      "NamePos": 367,
+                      "NameEnd": 371
+                    },
+                    "Value": {
+                      "LiteralPos": 373,
+                      "LiteralEnd": 380,
+                      "Literal": "API-KEY"
+                    },
+                    "Args": null,
+                    "LParenPos": 0,
+                    "RParenPos": 0
+                  },
+                  {
+                    "ArgPos": 382,
+                    "Name": {
+                      "Name": "value",
+                      "QuoteType": 1,
+                      "NamePos": 382,
+                      "NameEnd": 387
+                    },
+                    "Value": {
+                      "LiteralPos": 389,
+                      "LiteralEnd": 392,
+                      "Literal": "key"
+                    },
+                    "Args": null,
+                    "LParenPos": 0,
+                    "RParenPos": 0
+                  }
+                ],
+                "LParenPos": 366,
+                "RParenPos": 393
+              }
+            ],
+            "LParenPos": 359,
+            "RParenPos": 394
+          }
+        ],
+        "RParenPos": 397
+      },
+      "Lifetime": {
+        "LifetimePos": 399,
+        "Min": {
+          "NumPos": 412,
+          "NumEnd": 413,
+          "Literal": "0",
+          "Base": 10
+        },
+        "Max": {
+          "NumPos": 418,
+          "NumEnd": 422,
+          "Literal": "3600",
+          "Base": 10
+        },
+        "Value": null,
+        "RParenPos": 422
+      },
+      "Layout": {
+        "LayoutPos": 424,
+        "Layout": {
+          "Name": "HASHED",
+          "QuoteType": 1,
+          "NamePos": 431,
+          "NameEnd": 437
+        },
+        "Args": null,
+        "RParenPos": 439
+      },
+      "Range": null,
+      "Settings": null
+    },
+    "Comment": null
+  }
+]

--- a/parser/testdata/ddl/output/create_dictionary_with_comment.sql.golden.json
+++ b/parser/testdata/ddl/output/create_dictionary_with_comment.sql.golden.json
@@ -239,7 +239,10 @@
               "LiteralPos": 269,
               "LiteralEnd": 278,
               "Literal": "localhost"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 284,
@@ -254,7 +257,10 @@
               "NumEnd": 293,
               "Literal": "3306",
               "Base": 10
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 298,
@@ -268,7 +274,10 @@
               "LiteralPos": 304,
               "LiteralEnd": 311,
               "Literal": "default"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 317,
@@ -282,7 +291,10 @@
               "LiteralPos": 327,
               "LiteralEnd": 327,
               "Literal": ""
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 333,
@@ -296,7 +308,10 @@
               "LiteralPos": 337,
               "LiteralEnd": 341,
               "Literal": "test"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           },
           {
             "ArgPos": 347,
@@ -310,7 +325,10 @@
               "LiteralPos": 354,
               "LiteralEnd": 364,
               "Literal": "dict_table"
-            }
+            },
+            "Args": null,
+            "LParenPos": 0,
+            "RParenPos": 0
           }
         ],
         "RParenPos": 367

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -1327,6 +1327,11 @@ func Walk(node Expr, fn WalkFunc) bool {
 		if !Walk(n.Value, fn) {
 			return false
 		}
+		for _, arg := range n.Args {
+			if !Walk(arg, fn) {
+				return false
+			}
+		}
 	case *DictionaryLifetimeClause:
 		if !Walk(n.Value, fn) {
 			return false


### PR DESCRIPTION
Dictionary argument names come from the source configuration, so they can be any word. SOURCE(HTTP(URL 'http://o/asns.csv' FORMAT 'CSVWithNames')) failed because FORMAT is a reserved keyword, so argument names now go through parseAnyKeyword.

An argument may also hold its own list of arguments, as in CREDENTIALS(USER 'u' PASSWORD 'p') or HEADERS(HEADER(NAME 'k' VALUE 'v')), which the grammar had no notion of. DictionaryArgExpr now carries either a value or a nested list, told apart by LParenPos so that a list with no argument is not read as a missing value. The source and layout clauses share the argument loop with the nested lists.

Both statements were checked against clickhouse-local 26.2.5, which also accepts the formatted output.