### PR TITLE
Add support for ALTER TABLE ... MODIFY ORDER BY

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -912,6 +912,33 @@ func (a *AlterTableModifyQuery) Accept(visitor ASTVisitor) error {
 	return visitor.VisitAlterTableModifyQuery(a)
 }
 
+type AlterTableModifyOrderBy struct {
+	ModifyPos    Pos
+	StatementEnd Pos
+	OrderBy      Expr
+}
+
+func (a *AlterTableModifyOrderBy) Pos() Pos {
+	return a.ModifyPos
+}
+
+func (a *AlterTableModifyOrderBy) End() Pos {
+	return a.StatementEnd
+}
+
+func (a *AlterTableModifyOrderBy) AlterType() string {
+	return "MODIFY_ORDER_BY"
+}
+
+func (a *AlterTableModifyOrderBy) Accept(visitor ASTVisitor) error {
+	visitor.Enter(a)
+	defer visitor.Leave(a)
+	if err := a.OrderBy.Accept(visitor); err != nil {
+		return err
+	}
+	return visitor.VisitAlterTableModifyOrderBy(a)
+}
+
 type AlterTableModifyTTL struct {
 	ModifyPos    Pos
 	StatementEnd Pos

--- a/parser/ast_visitor.go
+++ b/parser/ast_visitor.go
@@ -28,6 +28,7 @@ type ASTVisitor interface {
 	VisitAlterTableRenameColumn(expr *AlterTableRenameColumn) error
 	VisitAlterTableModifyTTL(expr *AlterTableModifyTTL) error
 	VisitAlterTableModifyQuery(expr *AlterTableModifyQuery) error
+	VisitAlterTableModifyOrderBy(expr *AlterTableModifyOrderBy) error
 	VisitAlterTableModifyColumn(expr *AlterTableModifyColumn) error
 	VisitAlterTableModifySetting(expr *AlterTableModifySetting) error
 	VisitAlterTableResetSetting(expr *AlterTableResetSetting) error
@@ -390,6 +391,13 @@ func (v *DefaultASTVisitor) VisitAlterTableRenameColumn(expr *AlterTableRenameCo
 }
 
 func (v *DefaultASTVisitor) VisitAlterTableModifyQuery(expr *AlterTableModifyQuery) error {
+	if v.Visit != nil {
+		return v.Visit(expr)
+	}
+	return nil
+}
+
+func (v *DefaultASTVisitor) VisitAlterTableModifyOrderBy(expr *AlterTableModifyOrderBy) error {
 	if v.Visit != nil {
 		return v.Visit(expr)
 	}

--- a/parser/format.go
+++ b/parser/format.go
@@ -432,6 +432,11 @@ func (a *AlterTableModifyQuery) FormatSQL(formatter *Formatter) {
 	formatter.Dedent()
 }
 
+func (a *AlterTableModifyOrderBy) FormatSQL(formatter *Formatter) {
+	formatter.WriteString("MODIFY ORDER BY ")
+	formatter.WriteExpr(a.OrderBy)
+}
+
 func (a *AlterTableModifySetting) FormatSQL(formatter *Formatter) {
 	formatter.WriteString("MODIFY SETTING")
 	formatter.Indent()

--- a/parser/parser_alter.go
+++ b/parser/parser_alter.go
@@ -679,6 +679,20 @@ func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
 			StatementEnd: selectQuery.End(),
 			SelectExpr:   selectQuery,
 		}, nil
+	case p.matchKeyword(KeywordOrder):
+		_ = p.lexer.consumeToken() // consume "ORDER"
+		if err := p.expectKeyword(KeywordBy); err != nil {
+			return nil, err
+		}
+		orderBy, err := p.parseExpr(p.Pos())
+		if err != nil {
+			return nil, err
+		}
+		return &AlterTableModifyOrderBy{
+			ModifyPos:    pos,
+			StatementEnd: orderBy.End(),
+			OrderBy:      orderBy,
+		}, nil
 	case p.matchKeyword(KeywordSetting):
 		_ = p.lexer.consumeToken() // consume "SETTING"
 		settings, err := p.parseSettingsList(p.Pos())
@@ -693,7 +707,7 @@ func (p *Parser) parseAlterTableModify(pos Pos) (AlterTableClause, error) {
 			Settings:     settings,
 		}, nil
 	default:
-		return nil, fmt.Errorf("expected keyword: COLUMN|TTL|QUERY|SETTING, but got %q",
+		return nil, fmt.Errorf("expected keyword: COLUMN|TTL|QUERY|ORDER|SETTING, but got %q",
 			p.currentTokenString())
 	}
 

--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -953,6 +953,29 @@ func (p *Parser) tryParseOrderByClause(pos Pos) (*OrderByClause, error) {
 	return p.parseOrderByClause(pos)
 }
 
+// tryParseTableOrderByClause parses the ORDER BY of a table engine, which gives
+// the sorting key. Unlike the ORDER BY of a query it holds a single expression:
+// a sorting key over several columns is written as a tuple.
+func (p *Parser) tryParseTableOrderByClause(pos Pos) (*OrderByClause, error) {
+	if !p.tryConsumeKeywords(KeywordOrder) {
+		return nil, nil // nolint
+	}
+
+	if err := p.expectKeyword(KeywordBy); err != nil {
+		return nil, err
+	}
+
+	sortingKey, err := p.parseOrderExpr(pos)
+	if err != nil {
+		return nil, err
+	}
+	return &OrderByClause{
+		OrderPos: pos,
+		ListEnd:  sortingKey.End(),
+		Items:    []Expr{sortingKey},
+	}, nil
+}
+
 func (p *Parser) parseOrderByClause(pos Pos) (*OrderByClause, error) {
 	orderByListExpr := &OrderByClause{OrderPos: pos, ListEnd: pos}
 	items := make([]Expr, 0)
@@ -1403,7 +1426,7 @@ func (p *Parser) parseEngineExpr(pos Pos) (*EngineExpr, error) {
 	for !p.lexer.isEOF() {
 		switch {
 		case p.matchKeyword(KeywordOrder):
-			orderBy, err := p.tryParseOrderByClause(p.Pos())
+			orderBy, err := p.tryParseTableOrderByClause(p.Pos())
 			if err != nil {
 				return nil, err
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -183,6 +183,11 @@ func TestParser_InvalidSyntax(t *testing.T) {
 		"SELECT n FROM t ORDER BY n WITH FILL INTERPOLATE (x",         // Missing closing paren
 		"SELECT n FROM t ORDER BY n WITH FILL INTERPOLATE x AS x + 1", // Missing parens around column list
 		"ALTER TABLE foo_mv MODIFY QUERY AS SELECT * FROM baz",        // MODIFY QUERY followed by an invalid query
+		// A sorting key is a single expression, so a key over several columns
+		// is written as a tuple. A comma starts the next engine clause in
+		// CREATE TABLE and the next clause in ALTER TABLE.
+		"CREATE TABLE t (a DateTime, b String) ENGINE = MergeTree ORDER BY a, b",
+		"ALTER TABLE t MODIFY ORDER BY a, b",
 		// Invalid ARRAY JOIN types (only ARRAY JOIN, LEFT ARRAY JOIN, and INNER ARRAY JOIN are valid)
 		"SELECT * FROM t RIGHT ARRAY JOIN arr AS a", // RIGHT ARRAY JOIN not supported
 		"SELECT * FROM t FULL ARRAY JOIN arr AS a",  // FULL ARRAY JOIN not supported

--- a/parser/testdata/ddl/alter_table_modify_order_by.sql
+++ b/parser/testdata/ddl/alter_table_modify_order_by.sql
@@ -1,0 +1,4 @@
+ALTER TABLE flows MODIFY ORDER BY (TimeReceived, ExporterAddress);
+ALTER TABLE flows MODIFY ORDER BY TimeReceived;
+ALTER TABLE db.flows ON CLUSTER c MODIFY ORDER BY (TimeReceived, toStartOfHour(TimeReceived));
+ALTER TABLE flows ADD COLUMN ExporterAddress String, MODIFY ORDER BY (TimeReceived, ExporterAddress);

--- a/parser/testdata/ddl/format/alter_table_modify_order_by.sql
+++ b/parser/testdata/ddl/format/alter_table_modify_order_by.sql
@@ -1,0 +1,12 @@
+-- Origin SQL:
+ALTER TABLE flows MODIFY ORDER BY (TimeReceived, ExporterAddress);
+ALTER TABLE flows MODIFY ORDER BY TimeReceived;
+ALTER TABLE db.flows ON CLUSTER c MODIFY ORDER BY (TimeReceived, toStartOfHour(TimeReceived));
+ALTER TABLE flows ADD COLUMN ExporterAddress String, MODIFY ORDER BY (TimeReceived, ExporterAddress);
+
+
+-- Format SQL:
+ALTER TABLE flows MODIFY ORDER BY (TimeReceived, ExporterAddress);
+ALTER TABLE flows MODIFY ORDER BY TimeReceived;
+ALTER TABLE db.flows ON CLUSTER c MODIFY ORDER BY (TimeReceived, toStartOfHour(TimeReceived));
+ALTER TABLE flows ADD COLUMN ExporterAddress String, MODIFY ORDER BY (TimeReceived, ExporterAddress);

--- a/parser/testdata/ddl/format/beautify/alter_table_modify_order_by.sql
+++ b/parser/testdata/ddl/format/beautify/alter_table_modify_order_by.sql
@@ -1,0 +1,18 @@
+-- Origin SQL:
+ALTER TABLE flows MODIFY ORDER BY (TimeReceived, ExporterAddress);
+ALTER TABLE flows MODIFY ORDER BY TimeReceived;
+ALTER TABLE db.flows ON CLUSTER c MODIFY ORDER BY (TimeReceived, toStartOfHour(TimeReceived));
+ALTER TABLE flows ADD COLUMN ExporterAddress String, MODIFY ORDER BY (TimeReceived, ExporterAddress);
+
+
+-- Beautify SQL:
+ALTER TABLE flows
+MODIFY ORDER BY (TimeReceived, ExporterAddress);
+ALTER TABLE flows
+MODIFY ORDER BY TimeReceived;
+ALTER TABLE db.flows
+ON CLUSTER c
+MODIFY ORDER BY (TimeReceived, toStartOfHour(TimeReceived));
+ALTER TABLE flows
+ADD COLUMN ExporterAddress String,
+MODIFY ORDER BY (TimeReceived, ExporterAddress);

--- a/parser/testdata/ddl/output/alter_table_modify_order_by.sql.golden.json
+++ b/parser/testdata/ddl/output/alter_table_modify_order_by.sql.golden.json
@@ -1,0 +1,251 @@
+[
+  {
+    "AlterPos": 0,
+    "StatementEnd": 64,
+    "TableIdentifier": {
+      "Database": null,
+      "Table": {
+        "Name": "flows",
+        "QuoteType": 1,
+        "NamePos": 12,
+        "NameEnd": 17
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "ModifyPos": 18,
+        "StatementEnd": 64,
+        "OrderBy": {
+          "LeftParenPos": 34,
+          "RightParenPos": 64,
+          "Items": {
+            "ListPos": 35,
+            "ListEnd": 64,
+            "HasDistinct": false,
+            "Items": [
+              {
+                "Expr": {
+                  "Name": "TimeReceived",
+                  "QuoteType": 1,
+                  "NamePos": 35,
+                  "NameEnd": 47
+                },
+                "Alias": null
+              },
+              {
+                "Expr": {
+                  "Name": "ExporterAddress",
+                  "QuoteType": 1,
+                  "NamePos": 49,
+                  "NameEnd": 64
+                },
+                "Alias": null
+              }
+            ]
+          },
+          "ColumnArgList": null
+        }
+      }
+    ]
+  },
+  {
+    "AlterPos": 67,
+    "StatementEnd": 113,
+    "TableIdentifier": {
+      "Database": null,
+      "Table": {
+        "Name": "flows",
+        "QuoteType": 1,
+        "NamePos": 79,
+        "NameEnd": 84
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "ModifyPos": 85,
+        "StatementEnd": 113,
+        "OrderBy": {
+          "Name": "TimeReceived",
+          "QuoteType": 1,
+          "NamePos": 101,
+          "NameEnd": 113
+        }
+      }
+    ]
+  },
+  {
+    "AlterPos": 115,
+    "StatementEnd": 207,
+    "TableIdentifier": {
+      "Database": {
+        "Name": "db",
+        "QuoteType": 1,
+        "NamePos": 127,
+        "NameEnd": 129
+      },
+      "Table": {
+        "Name": "flows",
+        "QuoteType": 1,
+        "NamePos": 130,
+        "NameEnd": 135
+      }
+    },
+    "OnCluster": {
+      "OnPos": 136,
+      "Expr": {
+        "Name": "c",
+        "QuoteType": 1,
+        "NamePos": 147,
+        "NameEnd": 148
+      }
+    },
+    "AlterExprs": [
+      {
+        "ModifyPos": 149,
+        "StatementEnd": 207,
+        "OrderBy": {
+          "LeftParenPos": 165,
+          "RightParenPos": 207,
+          "Items": {
+            "ListPos": 166,
+            "ListEnd": 206,
+            "HasDistinct": false,
+            "Items": [
+              {
+                "Expr": {
+                  "Name": "TimeReceived",
+                  "QuoteType": 1,
+                  "NamePos": 166,
+                  "NameEnd": 178
+                },
+                "Alias": null
+              },
+              {
+                "Expr": {
+                  "Name": {
+                    "Name": "toStartOfHour",
+                    "QuoteType": 1,
+                    "NamePos": 180,
+                    "NameEnd": 193
+                  },
+                  "Params": {
+                    "LeftParenPos": 193,
+                    "RightParenPos": 206,
+                    "Items": {
+                      "ListPos": 194,
+                      "ListEnd": 206,
+                      "HasDistinct": false,
+                      "Items": [
+                        {
+                          "Expr": {
+                            "Name": "TimeReceived",
+                            "QuoteType": 1,
+                            "NamePos": 194,
+                            "NameEnd": 206
+                          },
+                          "Alias": null
+                        }
+                      ]
+                    },
+                    "ColumnArgList": null
+                  }
+                },
+                "Alias": null
+              }
+            ]
+          },
+          "ColumnArgList": null
+        }
+      }
+    ]
+  },
+  {
+    "AlterPos": 210,
+    "StatementEnd": 309,
+    "TableIdentifier": {
+      "Database": null,
+      "Table": {
+        "Name": "flows",
+        "QuoteType": 1,
+        "NamePos": 222,
+        "NameEnd": 227
+      }
+    },
+    "OnCluster": null,
+    "AlterExprs": [
+      {
+        "AddPos": 228,
+        "StatementEnd": 261,
+        "Column": {
+          "NamePos": 239,
+          "ColumnEnd": 261,
+          "Name": {
+            "Ident": {
+              "Name": "ExporterAddress",
+              "QuoteType": 1,
+              "NamePos": 239,
+              "NameEnd": 254
+            },
+            "DotIdent": null
+          },
+          "Type": {
+            "Name": {
+              "Name": "String",
+              "QuoteType": 1,
+              "NamePos": 255,
+              "NameEnd": 261
+            }
+          },
+          "NotNull": null,
+          "Nullable": null,
+          "DefaultExpr": null,
+          "MaterializedExpr": null,
+          "AliasExpr": null,
+          "Codec": null,
+          "TTL": null,
+          "Comment": null,
+          "CompressionCodec": null
+        },
+        "IfNotExists": false,
+        "After": null,
+        "Settings": null
+      },
+      {
+        "ModifyPos": 263,
+        "StatementEnd": 309,
+        "OrderBy": {
+          "LeftParenPos": 279,
+          "RightParenPos": 309,
+          "Items": {
+            "ListPos": 280,
+            "ListEnd": 309,
+            "HasDistinct": false,
+            "Items": [
+              {
+                "Expr": {
+                  "Name": "TimeReceived",
+                  "QuoteType": 1,
+                  "NamePos": 280,
+                  "NameEnd": 292
+                },
+                "Alias": null
+              },
+              {
+                "Expr": {
+                  "Name": "ExporterAddress",
+                  "QuoteType": 1,
+                  "NamePos": 294,
+                  "NameEnd": 309
+                },
+                "Alias": null
+              }
+            ]
+          },
+          "ColumnArgList": null
+        }
+      }
+    ]
+  }
+]

--- a/parser/walk.go
+++ b/parser/walk.go
@@ -945,6 +945,10 @@ func Walk(node Expr, fn WalkFunc) bool {
 		if !Walk(n.SelectExpr, fn) {
 			return false
 		}
+	case *AlterTableModifyOrderBy:
+		if !Walk(n.OrderBy, fn) {
+			return false
+		}
 	case *AlterTableModifyTTL:
 		if !Walk(n.TTL, fn) {
 			return false


### PR DESCRIPTION
MODIFY ORDER BY replaces the sorting key of a MergeTree table, as in
ALTER TABLE flows MODIFY ORDER BY (TimeReceived, ExporterAddress). The
new AlterTableModifyOrderBy clause follows the shape of the other MODIFY
clauses and holds the key as a single expression.

A single expression (as a tuple) is used rather than an order by list:
inside an ALTER a comma starts the next clause, so a key over several
columns is written as a tuple and reusing parseOrderByClause would
swallow the following clause.

The code is different than for CREATE TABLE, as this one accepts ORDER
BY a DESC. However, it should require an expression (a tuple for
multiple columns). This is fixed in the next commit.

Checked against clickhouse-local 26.2.5.