### PR TITLE
fix: Accept reserved keyword as expression operand

### DIFF
--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -104,69 +104,6 @@ func TestReservedKeywordInDisambiguatedPositions(t *testing.T) {
 	}
 }
 
-func TestReservedKeywordAsOperandInExpression(t *testing.T) {
-	cases := []string{
-		"SELECT x FROM t WHERE limit > 0",
-		"SELECT x FROM t WHERE from = 1 AND limit <= 10",
-		"SELECT x FROM t WHERE limit != 0 AND limit == 1",
-		"SELECT x FROM t WHERE limit >= 1 AND limit < 9",
-		"SELECT limit > 0 FROM t",
-		"SELECT limit + offset, limit - offset, limit % 2 FROM t",
-		"SELECT limit * 100 / total FROM t",
-		"SELECT from || to FROM t",
-		"SELECT toFloat64(limit) FROM t",
-		"SELECT max(limit), sum(offset) FROM t",
-		"SELECT if(limit > 0, limit, 0) FROM t",
-		"SELECT limit::UInt8 FROM t",
-		"SELECT [limit][1] FROM t",
-		"SELECT arr[limit] FROM t",
-		"SELECT (limit, offset) FROM t",
-		"SELECT x FROM t GROUP BY limit HAVING limit > 1",
-		"SELECT x FROM t ORDER BY limit / total DESC",
-		"SELECT x FROM t PREWHERE limit > 0 WHERE offset > 0",
-		"SELECT sum(limit) OVER (PARTITION BY from ORDER BY limit) FROM t",
-		"SELECT x FROM t WHERE limit > 0 LIMIT 10",
-		"SELECT x FROM (SELECT limit FROM t) WHERE limit > 0",
-		"WITH cte AS (SELECT 1 AS limit) SELECT limit * 2 FROM cte",
-		"SELECT x FROM t WHERE toFloat64(a.limit) / b.limit > 0.5",
-		"SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM t",
-		"SELECT count() FROM t WHERE limit IN (1, 2)",
-		"INSERT INTO t SELECT limit + 1 FROM s",
-		"CREATE VIEW v AS SELECT limit * 2 FROM t",
-		"ALTER TABLE t UPDATE x = limit + 1 WHERE limit > 0",
-	}
-	for _, sql := range cases {
-		t.Run(sql, func(t *testing.T) {
-			_, err := NewParser(sql).ParseStmts()
-			require.NoError(t, err)
-		})
-	}
-}
-
-func TestReservedKeywordOperandRoundTrip(t *testing.T) {
-	cases := []struct {
-		sql  string
-		want string
-	}{
-		{"SELECT x FROM t WHERE limit > 0", "SELECT x FROM t WHERE limit > 0"},
-		{"SELECT toFloat64(limit) AS limit FROM t", "SELECT toFloat64(limit) AS limit FROM t"},
-		{"SELECT limit::UInt8 FROM t", "SELECT limit::UInt8 FROM t"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.sql, func(t *testing.T) {
-			stmts, err := NewParser(tc.sql).ParseStmts()
-			require.NoError(t, err)
-			require.Len(t, stmts, 1)
-
-			formatted := Format(stmts[0])
-			require.Equal(t, tc.want, formatted)
-
-			_, err = NewParser(formatted).ParseStmts()
-			require.NoError(t, err)
-		})
-	}
-}
-
 func TestExpressionContinuationDoesNotWeakenClauseParsing(t *testing.T) {
 	cases := []string{
 		"SELECT a FROM WHERE b = 1",

--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -104,6 +104,31 @@ func TestReservedKeywordInDisambiguatedPositions(t *testing.T) {
 	}
 }
 
+// TestReservedKeywordAsOperandInExpression asserts that a reserved keyword is
+// accepted as a column name wherever the following token can only continue an
+// expression - a binary operator, `::`, or the closer of an argument list,
+// tuple, or subscript. ClickHouse server accepts all of these unquoted.
+func TestReservedKeywordAsOperandInExpression(t *testing.T) {
+	cases := []string{
+		"SELECT x FROM t WHERE limit > 0",
+		"SELECT x FROM t WHERE from = 1 AND limit <= 10",
+		"SELECT limit > 0 FROM t",
+		"SELECT limit * 100 / total FROM t",
+		"SELECT toFloat64(limit) FROM t",
+		"SELECT max(limit), sum(offset) FROM t",
+		"SELECT limit::UInt8 FROM t",
+		"SELECT [limit][1] FROM t",
+		"SELECT (limit, offset) FROM t",
+		"SELECT x FROM t GROUP BY limit HAVING limit > 1",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestReservedOperatorKeywordsAreCallable covers the regressions from the
 // review of #275: operator keywords double as ordinary ClickHouse function
 // names and must stay callable when followed by '('.

--- a/parser/keyword_test.go
+++ b/parser/keyword_test.go
@@ -104,22 +104,98 @@ func TestReservedKeywordInDisambiguatedPositions(t *testing.T) {
 	}
 }
 
-// TestReservedKeywordAsOperandInExpression asserts that a reserved keyword is
-// accepted as a column name wherever the following token can only continue an
-// expression - a binary operator, `::`, or the closer of an argument list,
-// tuple, or subscript. ClickHouse server accepts all of these unquoted.
 func TestReservedKeywordAsOperandInExpression(t *testing.T) {
 	cases := []string{
 		"SELECT x FROM t WHERE limit > 0",
 		"SELECT x FROM t WHERE from = 1 AND limit <= 10",
+		"SELECT x FROM t WHERE limit != 0 AND limit == 1",
+		"SELECT x FROM t WHERE limit >= 1 AND limit < 9",
 		"SELECT limit > 0 FROM t",
+		"SELECT limit + offset, limit - offset, limit % 2 FROM t",
 		"SELECT limit * 100 / total FROM t",
+		"SELECT from || to FROM t",
 		"SELECT toFloat64(limit) FROM t",
 		"SELECT max(limit), sum(offset) FROM t",
+		"SELECT if(limit > 0, limit, 0) FROM t",
 		"SELECT limit::UInt8 FROM t",
 		"SELECT [limit][1] FROM t",
+		"SELECT arr[limit] FROM t",
 		"SELECT (limit, offset) FROM t",
 		"SELECT x FROM t GROUP BY limit HAVING limit > 1",
+		"SELECT x FROM t ORDER BY limit / total DESC",
+		"SELECT x FROM t PREWHERE limit > 0 WHERE offset > 0",
+		"SELECT sum(limit) OVER (PARTITION BY from ORDER BY limit) FROM t",
+		"SELECT x FROM t WHERE limit > 0 LIMIT 10",
+		"SELECT x FROM (SELECT limit FROM t) WHERE limit > 0",
+		"WITH cte AS (SELECT 1 AS limit) SELECT limit * 2 FROM cte",
+		"SELECT x FROM t WHERE toFloat64(a.limit) / b.limit > 0.5",
+		"SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM t",
+		"SELECT count() FROM t WHERE limit IN (1, 2)",
+		"INSERT INTO t SELECT limit + 1 FROM s",
+		"CREATE VIEW v AS SELECT limit * 2 FROM t",
+		"ALTER TABLE t UPDATE x = limit + 1 WHERE limit > 0",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestReservedKeywordOperandRoundTrip(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want string
+	}{
+		{"SELECT x FROM t WHERE limit > 0", "SELECT x FROM t WHERE limit > 0"},
+		{"SELECT toFloat64(limit) AS limit FROM t", "SELECT toFloat64(limit) AS limit FROM t"},
+		{"SELECT limit::UInt8 FROM t", "SELECT limit::UInt8 FROM t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			stmts, err := NewParser(tc.sql).ParseStmts()
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			formatted := Format(stmts[0])
+			require.Equal(t, tc.want, formatted)
+
+			_, err = NewParser(formatted).ParseStmts()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestExpressionContinuationDoesNotWeakenClauseParsing(t *testing.T) {
+	cases := []string{
+		"SELECT a FROM WHERE b = 1",
+		"SELECT a, b FROM GROUP BY a",
+		"SELECT a AS FROM t",
+		"SELECT a FROM t JOIN ON a = b",
+		"SELECT CASE WHEN a THEN 1 ELSE 2 FROM t",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			_, err := NewParser(sql).ParseStmts()
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestClauseKeywordsStillParseAsClauses(t *testing.T) {
+	cases := []string{
+		"SELECT a FROM t LIMIT 10",
+		"SELECT a FROM t LIMIT 10 OFFSET 5",
+		"SELECT a FROM t LIMIT 1 BY a",
+		"SELECT a FROM t ORDER BY a DESC LIMIT 5",
+		"SELECT DISTINCT a FROM t",
+		"SELECT a FROM t UNION ALL SELECT b FROM s",
+		"SELECT a FROM t WHERE a BETWEEN 1 AND 2",
+		"SELECT INTERVAL 1 DAY",
+		"SELECT a + INTERVAL 1 DAY FROM t",
+		"SELECT * EXCEPT (a) FROM t",
+		"SELECT a FROM t FORMAT JSON",
 	}
 	for _, sql := range cases {
 		t.Run(sql, func(t *testing.T) {

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -480,6 +480,30 @@ func (p *Parser) peekIsEndOfStatement() bool {
 	return next.Kind == ";"
 }
 
+// expressionContinuationTokenKinds are the token kinds that can only follow a
+// complete expression: binary operators, the cast operator, and the closers of
+// an argument list, a tuple, or an array subscript. None of them can follow a
+// clause or expression starter, so a keyword in front of one is being used as
+// an operand — a column name.
+var expressionContinuationTokenKinds = []TokenKind{
+	TokenKindSingleEQ, TokenKindDoubleEQ, TokenKindNE,
+	TokenKindLT, TokenKindLE, TokenKindGT, TokenKindGE,
+	TokenKindPlus, TokenKindMinus, TokenKindMul, TokenKindDiv, TokenKindMod,
+	TokenKindConcat, TokenKindDash,
+	TokenKindRParen, TokenKindRBracket,
+}
+
+// peekIsExpressionContinuation reports whether the next token is one of
+// expressionContinuationTokenKinds.
+func (p *Parser) peekIsExpressionContinuation() bool {
+	for _, kind := range expressionContinuationTokenKinds {
+		if p.peekTokenKind(kind) {
+			return true
+		}
+	}
+	return false
+}
+
 // keywordIsSelectItemIdentifier reports whether the current keyword token is
 // being used as a bare column-reference identifier inside a SELECT projection
 // rather than starting a clause/expression. This is true when the next token
@@ -531,8 +555,14 @@ func (p *Parser) parseColumnExpr(pos Pos) (Expr, error) { //nolint:funlen
 	// is only valid in expression position, so it's applied inline here
 	// rather than in keywordIsSelectItemIdentifier (which is shared with the
 	// terminator/alias check).
+	//
+	// The same holds for a keyword followed by a binary operator, `::`, `)` or
+	// `]` (e.g. `WHERE limit > 0`, `toFloat64(limit)`, `SELECT limit > 0`):
+	// those tokens can only continue an expression whose operand is the
+	// keyword, so in expression position the keyword is a column name.
 	if p.keywordIsSelectItemIdentifier() ||
-		(p.matchTokenKind(TokenKindKeyword) && p.peekIsEndOfStatement()) {
+		(p.matchTokenKind(TokenKindKeyword) &&
+			(p.peekIsEndOfStatement() || p.peekIsExpressionContinuation())) {
 		return p.parseAnyKeyword()
 	}
 	switch {

--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -480,11 +480,6 @@ func (p *Parser) peekIsEndOfStatement() bool {
 	return next.Kind == ";"
 }
 
-// expressionContinuationTokenKinds are the token kinds that can only follow a
-// complete expression: binary operators, the cast operator, and the closers of
-// an argument list, a tuple, or an array subscript. None of them can follow a
-// clause or expression starter, so a keyword in front of one is being used as
-// an operand — a column name.
 var expressionContinuationTokenKinds = []TokenKind{
 	TokenKindSingleEQ, TokenKindDoubleEQ, TokenKindNE,
 	TokenKindLT, TokenKindLE, TokenKindGT, TokenKindGE,
@@ -493,11 +488,19 @@ var expressionContinuationTokenKinds = []TokenKind{
 	TokenKindRParen, TokenKindRBracket,
 }
 
-// peekIsExpressionContinuation reports whether the next token is one of
-// expressionContinuationTokenKinds.
+var expressionContinuationKeywords = []string{
+	KeywordAnd, KeywordOr, KeywordNot, KeywordIn, KeywordLike, KeywordIlike,
+	KeywordBetween, KeywordIs, KeywordThen, KeywordElse, KeywordEnd,
+}
+
 func (p *Parser) peekIsExpressionContinuation() bool {
 	for _, kind := range expressionContinuationTokenKinds {
 		if p.peekTokenKind(kind) {
+			return true
+		}
+	}
+	for _, keyword := range expressionContinuationKeywords {
+		if p.peekKeyword(keyword) {
 			return true
 		}
 	}
@@ -531,7 +534,8 @@ func (p *Parser) keywordIsSelectItemIdentifier() bool {
 	}
 	return p.peekTokenKind(TokenKindComma) ||
 		p.peekKeyword(KeywordAs) ||
-		p.peekIsClauseStarterKeyword()
+		p.peekIsClauseStarterKeyword() ||
+		p.peekIsExpressionContinuation()
 }
 
 // isSelectItemTerminatorKeyword checks whether the current token is a keyword
@@ -555,11 +559,6 @@ func (p *Parser) parseColumnExpr(pos Pos) (Expr, error) { //nolint:funlen
 	// is only valid in expression position, so it's applied inline here
 	// rather than in keywordIsSelectItemIdentifier (which is shared with the
 	// terminator/alias check).
-	//
-	// The same holds for a keyword followed by a binary operator, `::`, `)` or
-	// `]` (e.g. `WHERE limit > 0`, `toFloat64(limit)`, `SELECT limit > 0`):
-	// those tokens can only continue an expression whose operand is the
-	// keyword, so in expression position the keyword is a column name.
 	if p.keywordIsSelectItemIdentifier() ||
 		(p.matchTokenKind(TokenKindKeyword) &&
 			(p.peekIsEndOfStatement() || p.peekIsExpressionContinuation())) {

--- a/parser/testdata/query/format/beautify/select_keyword_operand_arithmetic.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_arithmetic.sql
@@ -1,0 +1,12 @@
+-- Origin SQL:
+SELECT limit + offset, limit - offset, limit % 2, limit * 100 / total FROM quotas
+
+
+-- Beautify SQL:
+SELECT
+  limit + offset,
+  limit - offset,
+  limit % 2,
+  limit * 100 / total
+FROM
+  quotas;

--- a/parser/testdata/query/format/beautify/select_keyword_operand_as_function_argument.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_as_function_argument.sql
@@ -1,0 +1,11 @@
+-- Origin SQL:
+SELECT toFloat64(limit), max(limit), if(limit > 0, limit, 0) FROM quotas
+
+
+-- Beautify SQL:
+SELECT
+  toFloat64(limit),
+  max(limit),
+  if(limit > 0, limit, 0)
+FROM
+  quotas;

--- a/parser/testdata/query/format/beautify/select_keyword_operand_before_operator_keyword.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_before_operator_keyword.sql
@@ -1,0 +1,16 @@
+-- Origin SQL:
+SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM quotas WHERE limit IN (1, 2) AND from = 1
+
+
+-- Beautify SQL:
+SELECT
+  CASE
+    WHEN limit > 0 THEN limit
+    ELSE offset
+  END
+FROM
+  quotas
+WHERE
+  limit IN (1, 2)
+AND
+  from = 1;

--- a/parser/testdata/query/format/beautify/select_keyword_operand_cast_and_subscript.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_cast_and_subscript.sql
@@ -1,0 +1,12 @@
+-- Origin SQL:
+SELECT limit::UInt8, [limit][1], arr[limit], (limit, offset) FROM quotas
+
+
+-- Beautify SQL:
+SELECT
+  limit::UInt8,
+  [limit][1],
+  arr[limit],
+  (limit, offset)
+FROM
+  quotas;

--- a/parser/testdata/query/format/beautify/select_keyword_operand_in_where.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_in_where.sql
@@ -1,0 +1,11 @@
+-- Origin SQL:
+SELECT x FROM quotas WHERE limit > 0
+
+
+-- Beautify SQL:
+SELECT
+  x
+FROM
+  quotas
+WHERE
+  limit > 0;

--- a/parser/testdata/query/format/beautify/select_keyword_operand_multiple_items.sql
+++ b/parser/testdata/query/format/beautify/select_keyword_operand_multiple_items.sql
@@ -1,0 +1,10 @@
+-- Origin SQL:
+SELECT limit + 1, offset + 1 FROM quotas
+
+
+-- Beautify SQL:
+SELECT
+  limit + 1,
+  offset + 1
+FROM
+  quotas;

--- a/parser/testdata/query/format/select_keyword_operand_arithmetic.sql
+++ b/parser/testdata/query/format/select_keyword_operand_arithmetic.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT limit + offset, limit - offset, limit % 2, limit * 100 / total FROM quotas
+
+
+-- Format SQL:
+SELECT limit + offset, limit - offset, limit % 2, limit * 100 / total FROM quotas;

--- a/parser/testdata/query/format/select_keyword_operand_as_function_argument.sql
+++ b/parser/testdata/query/format/select_keyword_operand_as_function_argument.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT toFloat64(limit), max(limit), if(limit > 0, limit, 0) FROM quotas
+
+
+-- Format SQL:
+SELECT toFloat64(limit), max(limit), if(limit > 0, limit, 0) FROM quotas;

--- a/parser/testdata/query/format/select_keyword_operand_before_operator_keyword.sql
+++ b/parser/testdata/query/format/select_keyword_operand_before_operator_keyword.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM quotas WHERE limit IN (1, 2) AND from = 1
+
+
+-- Format SQL:
+SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM quotas WHERE limit IN (1, 2) AND from = 1;

--- a/parser/testdata/query/format/select_keyword_operand_cast_and_subscript.sql
+++ b/parser/testdata/query/format/select_keyword_operand_cast_and_subscript.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT limit::UInt8, [limit][1], arr[limit], (limit, offset) FROM quotas
+
+
+-- Format SQL:
+SELECT limit::UInt8, [limit][1], arr[limit], (limit, offset) FROM quotas;

--- a/parser/testdata/query/format/select_keyword_operand_in_where.sql
+++ b/parser/testdata/query/format/select_keyword_operand_in_where.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT x FROM quotas WHERE limit > 0
+
+
+-- Format SQL:
+SELECT x FROM quotas WHERE limit > 0;

--- a/parser/testdata/query/format/select_keyword_operand_multiple_items.sql
+++ b/parser/testdata/query/format/select_keyword_operand_multiple_items.sql
@@ -1,0 +1,6 @@
+-- Origin SQL:
+SELECT limit + 1, offset + 1 FROM quotas
+
+
+-- Format SQL:
+SELECT limit + 1, offset + 1 FROM quotas;

--- a/parser/testdata/query/output/select_keyword_operand_arithmetic.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_arithmetic.sql.golden.json
@@ -1,0 +1,145 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 81,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 12
+          },
+          "Operation": "+",
+          "RightExpr": {
+            "Name": "offset",
+            "QuoteType": 1,
+            "NamePos": 15,
+            "NameEnd": 21
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 23,
+            "NameEnd": 28
+          },
+          "Operation": "-",
+          "RightExpr": {
+            "Name": "offset",
+            "QuoteType": 1,
+            "NamePos": 31,
+            "NameEnd": 37
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 39,
+            "NameEnd": 44
+          },
+          "Operation": "%",
+          "RightExpr": {
+            "NumPos": 47,
+            "NumEnd": 48,
+            "Literal": "2",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "LeftExpr": {
+            "LeftExpr": {
+              "Name": "limit",
+              "QuoteType": 1,
+              "NamePos": 50,
+              "NameEnd": 55
+            },
+            "Operation": "*",
+            "RightExpr": {
+              "NumPos": 58,
+              "NumEnd": 61,
+              "Literal": "100",
+              "Base": 10
+            },
+            "HasGlobal": false,
+            "HasNot": false
+          },
+          "Operation": "/",
+          "RightExpr": {
+            "Name": "total",
+            "QuoteType": 1,
+            "NamePos": 64,
+            "NameEnd": 69
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 70,
+      "Expr": {
+        "Table": {
+          "TablePos": 75,
+          "TableEnd": 81,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 75,
+              "NameEnd": 81
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 81,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_keyword_operand_as_function_argument.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_as_function_argument.sql.golden.json
@@ -1,0 +1,178 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 72,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": {
+            "Name": "toFloat64",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 16
+          },
+          "Params": {
+            "LeftParenPos": 16,
+            "RightParenPos": 22,
+            "Items": {
+              "ListPos": 17,
+              "ListEnd": 22,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": "limit",
+                    "QuoteType": 1,
+                    "NamePos": 17,
+                    "NameEnd": 22
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Name": {
+            "Name": "max",
+            "QuoteType": 1,
+            "NamePos": 25,
+            "NameEnd": 28
+          },
+          "Params": {
+            "LeftParenPos": 28,
+            "RightParenPos": 34,
+            "Items": {
+              "ListPos": 29,
+              "ListEnd": 34,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": "limit",
+                    "QuoteType": 1,
+                    "NamePos": 29,
+                    "NameEnd": 34
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Name": {
+            "Name": "if",
+            "QuoteType": 1,
+            "NamePos": 37,
+            "NameEnd": 39
+          },
+          "Params": {
+            "LeftParenPos": 39,
+            "RightParenPos": 59,
+            "Items": {
+              "ListPos": 40,
+              "ListEnd": 59,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "LeftExpr": {
+                      "Name": "limit",
+                      "QuoteType": 1,
+                      "NamePos": 40,
+                      "NameEnd": 45
+                    },
+                    "Operation": "\u003e",
+                    "RightExpr": {
+                      "NumPos": 48,
+                      "NumEnd": 49,
+                      "Literal": "0",
+                      "Base": 10
+                    },
+                    "HasGlobal": false,
+                    "HasNot": false
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "Name": "limit",
+                    "QuoteType": 1,
+                    "NamePos": 51,
+                    "NameEnd": 56
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "NumPos": 58,
+                    "NumEnd": 59,
+                    "Literal": "0",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 61,
+      "Expr": {
+        "Table": {
+          "TablePos": 66,
+          "TableEnd": 72,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 66,
+              "NameEnd": 72
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 72,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_keyword_operand_before_operator_keyword.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_before_operator_keyword.sql.golden.json
@@ -1,0 +1,162 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 100,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "CasePos": 7,
+          "EndPos": 0,
+          "Expr": null,
+          "Whens": [
+            {
+              "WhenPos": 12,
+              "ThenPos": 27,
+              "When": {
+                "LeftExpr": {
+                  "Name": "limit",
+                  "QuoteType": 1,
+                  "NamePos": 17,
+                  "NameEnd": 22
+                },
+                "Operation": "\u003e",
+                "RightExpr": {
+                  "NumPos": 25,
+                  "NumEnd": 26,
+                  "Literal": "0",
+                  "Base": 10
+                },
+                "HasGlobal": false,
+                "HasNot": false
+              },
+              "Then": {
+                "Name": "limit",
+                "QuoteType": 1,
+                "NamePos": 32,
+                "NameEnd": 37
+              },
+              "ElsePos": 0,
+              "Else": null
+            }
+          ],
+          "ElsePos": 38,
+          "Else": {
+            "Name": "offset",
+            "QuoteType": 1,
+            "NamePos": 43,
+            "NameEnd": 49
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 54,
+      "Expr": {
+        "Table": {
+          "TablePos": 59,
+          "TableEnd": 65,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 59,
+              "NameEnd": 65
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 65,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 66,
+      "Expr": {
+        "LeftExpr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 72,
+            "NameEnd": 77
+          },
+          "Operation": "IN",
+          "RightExpr": {
+            "LeftParenPos": 81,
+            "RightParenPos": 86,
+            "Items": {
+              "ListPos": 82,
+              "ListEnd": 86,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 82,
+                    "NumEnd": 83,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "Alias": null
+                },
+                {
+                  "Expr": {
+                    "NumPos": 85,
+                    "NumEnd": 86,
+                    "Literal": "2",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            },
+            "ColumnArgList": null
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Operation": "AND",
+        "RightExpr": {
+          "LeftExpr": {
+            "Name": "from",
+            "QuoteType": 1,
+            "NamePos": 92,
+            "NameEnd": 96
+          },
+          "Operation": "=",
+          "RightExpr": {
+            "NumPos": 99,
+            "NumEnd": 100,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_keyword_operand_cast_and_subscript.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_cast_and_subscript.sql.golden.json
@@ -1,0 +1,183 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 72,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 12
+          },
+          "Operation": "::",
+          "RightExpr": {
+            "Name": "UInt8",
+            "QuoteType": 1,
+            "NamePos": 14,
+            "NameEnd": 19
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Object": {
+            "LeftBracketPos": 21,
+            "RightBracketPos": 27,
+            "Items": {
+              "ListPos": 22,
+              "ListEnd": 27,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": "limit",
+                    "QuoteType": 1,
+                    "NamePos": 22,
+                    "NameEnd": 27
+                  },
+                  "Alias": null
+                }
+              ]
+            }
+          },
+          "Params": {
+            "LeftBracketPos": 28,
+            "RightBracketPos": 30,
+            "Items": {
+              "ListPos": 29,
+              "ListEnd": 30,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "NumPos": 29,
+                    "NumEnd": 30,
+                    "Literal": "1",
+                    "Base": 10
+                  },
+                  "Alias": null
+                }
+              ]
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "Object": {
+            "Name": "arr",
+            "QuoteType": 1,
+            "NamePos": 33,
+            "NameEnd": 36
+          },
+          "Params": {
+            "LeftBracketPos": 36,
+            "RightBracketPos": 42,
+            "Items": {
+              "ListPos": 37,
+              "ListEnd": 42,
+              "HasDistinct": false,
+              "Items": [
+                {
+                  "Expr": {
+                    "Name": "limit",
+                    "QuoteType": 1,
+                    "NamePos": 37,
+                    "NameEnd": 42
+                  },
+                  "Alias": null
+                }
+              ]
+            }
+          }
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "LeftParenPos": 45,
+          "RightParenPos": 59,
+          "Items": {
+            "ListPos": 46,
+            "ListEnd": 59,
+            "HasDistinct": false,
+            "Items": [
+              {
+                "Expr": {
+                  "Name": "limit",
+                  "QuoteType": 1,
+                  "NamePos": 46,
+                  "NameEnd": 51
+                },
+                "Alias": null
+              },
+              {
+                "Expr": {
+                  "Name": "offset",
+                  "QuoteType": 1,
+                  "NamePos": 53,
+                  "NameEnd": 59
+                },
+                "Alias": null
+              }
+            ]
+          },
+          "ColumnArgList": null
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 61,
+      "Expr": {
+        "Table": {
+          "TablePos": 66,
+          "TableEnd": 72,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 66,
+              "NameEnd": 72
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 72,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_keyword_operand_in_where.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_in_where.sql.golden.json
@@ -1,0 +1,79 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 36,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "Name": "x",
+          "QuoteType": 1,
+          "NamePos": 7,
+          "NameEnd": 8
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 9,
+      "Expr": {
+        "Table": {
+          "TablePos": 14,
+          "TableEnd": 20,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 14,
+              "NameEnd": 20
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 20,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": {
+      "WherePos": 21,
+      "Expr": {
+        "LeftExpr": {
+          "Name": "limit",
+          "QuoteType": 1,
+          "NamePos": 27,
+          "NameEnd": 32
+        },
+        "Operation": "\u003e",
+        "RightExpr": {
+          "NumPos": 35,
+          "NumEnd": 36,
+          "Literal": "0",
+          "Base": 10
+        },
+        "HasGlobal": false,
+        "HasNot": false
+      }
+    },
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/output/select_keyword_operand_multiple_items.sql.golden.json
+++ b/parser/testdata/query/output/select_keyword_operand_multiple_items.sql.golden.json
@@ -1,0 +1,92 @@
+[
+  {
+    "SelectPos": 0,
+    "StatementEnd": 40,
+    "With": null,
+    "Top": null,
+    "HasDistinct": false,
+    "DistinctOn": null,
+    "SelectItems": [
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "limit",
+            "QuoteType": 1,
+            "NamePos": 7,
+            "NameEnd": 12
+          },
+          "Operation": "+",
+          "RightExpr": {
+            "NumPos": 15,
+            "NumEnd": 16,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      },
+      {
+        "Expr": {
+          "LeftExpr": {
+            "Name": "offset",
+            "QuoteType": 1,
+            "NamePos": 18,
+            "NameEnd": 24
+          },
+          "Operation": "+",
+          "RightExpr": {
+            "NumPos": 27,
+            "NumEnd": 28,
+            "Literal": "1",
+            "Base": 10
+          },
+          "HasGlobal": false,
+          "HasNot": false
+        },
+        "Modifiers": [],
+        "Alias": null
+      }
+    ],
+    "From": {
+      "FromPos": 29,
+      "Expr": {
+        "Table": {
+          "TablePos": 34,
+          "TableEnd": 40,
+          "Alias": null,
+          "Expr": {
+            "Database": null,
+            "Table": {
+              "Name": "quotas",
+              "QuoteType": 1,
+              "NamePos": 34,
+              "NameEnd": 40
+            }
+          },
+          "HasFinal": false
+        },
+        "StatementEnd": 40,
+        "SampleRatio": null,
+        "HasFinal": false
+      }
+    },
+    "Window": null,
+    "Prewhere": null,
+    "Where": null,
+    "GroupBy": null,
+    "WithTotal": false,
+    "Having": null,
+    "OrderBy": null,
+    "LimitBy": null,
+    "Limit": null,
+    "Settings": null,
+    "Format": null,
+    "UnionAll": null,
+    "UnionDistinct": null,
+    "Except": null,
+    "Intersect": null
+  }
+]

--- a/parser/testdata/query/select_keyword_operand_arithmetic.sql
+++ b/parser/testdata/query/select_keyword_operand_arithmetic.sql
@@ -1,0 +1,1 @@
+SELECT limit + offset, limit - offset, limit % 2, limit * 100 / total FROM quotas

--- a/parser/testdata/query/select_keyword_operand_as_function_argument.sql
+++ b/parser/testdata/query/select_keyword_operand_as_function_argument.sql
@@ -1,0 +1,1 @@
+SELECT toFloat64(limit), max(limit), if(limit > 0, limit, 0) FROM quotas

--- a/parser/testdata/query/select_keyword_operand_before_operator_keyword.sql
+++ b/parser/testdata/query/select_keyword_operand_before_operator_keyword.sql
@@ -1,0 +1,1 @@
+SELECT CASE WHEN limit > 0 THEN limit ELSE offset END FROM quotas WHERE limit IN (1, 2) AND from = 1

--- a/parser/testdata/query/select_keyword_operand_cast_and_subscript.sql
+++ b/parser/testdata/query/select_keyword_operand_cast_and_subscript.sql
@@ -1,0 +1,1 @@
+SELECT limit::UInt8, [limit][1], arr[limit], (limit, offset) FROM quotas

--- a/parser/testdata/query/select_keyword_operand_in_where.sql
+++ b/parser/testdata/query/select_keyword_operand_in_where.sql
@@ -1,0 +1,1 @@
+SELECT x FROM quotas WHERE limit > 0

--- a/parser/testdata/query/select_keyword_operand_multiple_items.sql
+++ b/parser/testdata/query/select_keyword_operand_multiple_items.sql
@@ -1,0 +1,1 @@
+SELECT limit + 1, offset + 1 FROM quotas


### PR DESCRIPTION
Reads a reserved keyword as a column name when the following token can only continue an expression - a binary operator, `::`, `)`, `]`, or one of AND/OR/NOT/IN/LIKE/ILIKE/BETWEEN/IS/THEN/ELSE/END - so that `WHERE limit > 0`, `toFloat64(limit)`, `SELECT limit + 1, offset + 1 FROM t` and `WHERE limit IN (1, 2)` parse as ClickHouse already accepts them (every added case was verified against ClickHouse 26.2).