### PR TITLE
Reject a trailing operator instead of dropping it at end of input

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -282,8 +282,15 @@ func (p *Parser) parseSubExpr(pos Pos, precedence int) (Expr, error) {
 // parseInfixLoop folds binary operators into expr while the next operator
 // binds tighter than precedence; it stops at once on tokens that are no
 // operator at all, such as ',' or ')'.
+//
+// The guard tests the lookahead token, not just the input offset: isEOF only
+// reports that no input text is left to lex, which is already true while the
+// final token sits unconsumed in p.current(). Stopping on isEOF alone dropped
+// a trailing operator instead of reporting its missing operand, so `SELECT a +`
+// left the '+' for the statement parser to reject as unexpected trailing input,
+// and `SELECT a GLOBAL` silently read the operator as an implicit alias.
 func (p *Parser) parseInfixLoop(expr Expr, precedence int) (Expr, error) {
-	for !p.lexer.isEOF() {
+	for !p.lexer.isEOF() || p.current() != nil {
 		nextPrecedence := p.getNextPrecedence()
 		if nextPrecedence <= precedence {
 			return expr, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -229,6 +229,14 @@ func TestParser_InvalidSyntax(t *testing.T) {
 		"ALTER ",
 		"SELECT*FROM A(0A",
 		"SET A=",
+		// An operator as the last token of the input is missing its right
+		// operand. The infix loop used to stop before it, so the operator
+		// either reached the statement parser as unexpected trailing input or,
+		// when it was a keyword, was read as an implicit alias.
+		"SELECT a +",
+		"SELECT a GLOBAL",
+		"SELECT a REGEXP",
+		"SELECT * FROM t WHERE a AND",
 	}
 	for _, sql := range invalidSQLs {
 		parser := NewParser(sql)


### PR DESCRIPTION
isEOF only reports that no input text is left to lex, which is already
true while the final token sits unconsumed in the lookahead. The infix
loop stopped on it, so an operator at the end of the input was dropped
rather than reported as missing its right operand.

Most such inputs still failed, but on the wrong token: SELECT a + left
the plus for the statement parser to reject as unexpected trailing
input. Two were accepted outright, because a dropped operator keyword
fell through to the implicit-alias logic: SELECT a GLOBAL parsed as
SELECT a AS GLOBAL, and SELECT a REGEXP as SELECT a AS REGEXP. The
invalid-syntax tests already record that GLOBAL is never an implicit
alias; it only slipped through at end of input.

Guard the loop on the lookahead token instead, which is the idiom
parseColumnExprListWithTerm and parseSelectItems already use. Entering
parseInfix on the final token is safe: every branch reads the current
token behind a match check, and each path to a right operand is nil-safe
at EOF. No valid statement ends in an infix operator, so the change only
turns silently truncated parses into errors, and no golden file moves.

clickhouse-local 26.7.1 rejects all four new cases, and accepts the
explicit SELECT 1 AS GLOBAL that the alias reading was confused with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)