### PR TITLE
Support function expressions in table settings

### DIFF
--- a/parser/parser_table.go
+++ b/parser/parser_table.go
@@ -1492,7 +1492,11 @@ func (p *Parser) parseSettingsExpr(pos Pos) (*SettingExpr, error) {
 			Literal:    curToken.String,
 		}
 	default:
-		return nil, fmt.Errorf("unexpected token: %q, expected <number>, <bool> or <string>", p.currentTokenString())
+		value, err := p.parseExpr(p.Pos())
+		if err != nil {
+			return nil, fmt.Errorf("invalid setting value: %w", err)
+		}
+		expr = value
 	}
 
 	return &SettingExpr{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -14,6 +14,23 @@ import (
 
 var runCompatible = flag.Bool("compatible", false, "run compatible test")
 
+func TestParser_TableSettingsFunctionExpression(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"function":        `CREATE TABLE t (timestamp DateTime64(9)) ENGINE = MergeTree ORDER BY timestamp SETTINGS table_disk = true, disk = disk(type = 's3_plain_rewritable', endpoint = 'from_env GCS_STORAGE_PATH_DATA', readonly = true)`,
+		"nested function": `CREATE TABLE t (timestamp DateTime64(9)) ENGINE = MergeTree ORDER BY timestamp SETTINGS table_disk = true, disk = disk(name = 'cache', type = 'cache', path = 'from_env CACHE_PATH', max_size = 'from_env CACHE_SIZE', enable_filesystem_query_cache_limit = true, disk = disk(type = 's3_plain_rewritable', endpoint = '[HIDDEN]', readonly = '[HIDDEN]'))`,
+	}
+
+	for name, query := range tests {
+		t.Run(name, func(t *testing.T) {
+			exprs, err := NewParser(query).ParseStmts()
+			require.NoError(t, err)
+			require.Len(t, exprs, 1)
+		})
+	}
+}
+
 func TestParser_Compatible(t *testing.T) {
 	if !*runCompatible {
 		t.Skip("Compatible test runs only if -compatible is set")


### PR DESCRIPTION
## What

Allow table `SETTINGS` values to use expressions in addition to scalar literals.

This adds support for ClickHouse table-disk definitions such as:

```sql
SETTINGS disk = disk(
    type = 's3_plain_rewritable',
    endpoint = 'from_env OBJECT_STORAGE_ENDPOINT',
    readonly = true
)
```

It also supports nested disk definitions used by cached reader tables.

## Why

The parser currently rejects function expressions in table settings:

```text
unexpected token: "disk", expected <number>, <bool> or <string>
```

This prevents callers from parsing `SHOW CREATE TABLE` output for tables using `s3_plain_rewritable` and cache disks.

## Validation

- `go test ./... -count=1`
- Added coverage for function and nested-function setting values

`go vet ./...` still reports the existing `Formatter.WriteByte` signature warning in `parser/format.go`.
