### PR TITLE
Fix token error handling in named type parameters

### DIFF
--- a/parser/parser_column.go
+++ b/parser/parser_column.go
@@ -1506,7 +1506,9 @@ func (p *Parser) parseColumnTypeWithNamedParams(name *Ident, leftParenPos Pos) (
 			Name:    paramName,
 			Value:   value,
 		})
-		if p.tryConsumeTokenKind(TokenKindComma) == nil {
+		if token, err := p.tryConsumeTokenKind(TokenKindComma); err != nil {
+			return nil, err
+		} else if token == nil {
 			break
 		}
 	}


### PR DESCRIPTION
## Problem

The named-type parameter parser still treats `tryConsumeTokenKind` as
returning only a token. After the helper gained an error return, this
caller prevents trunk from compiling.

## Reproduction

```text
go test ./...
parser/parser_column.go:1509:6: multiple-value p.tryConsumeTokenKind(TokenKindComma) (value of type (*Token, error)) in single-value context
```

## Fix

Handle the returned error before checking whether a comma was consumed.
This PR changes only that caller in `parseColumnTypeWithNamedParams`.

## Test

The existing named-type fixtures cover successful parsing. `make test`
(including race and compatibility tests), `make lint`, and `make` pass
with Go 1.21.13. Tests/lint use external linking on macOS.
